### PR TITLE
Fix duplicate imports

### DIFF
--- a/foamlib/_cases.py
+++ b/foamlib/_cases.py
@@ -14,7 +14,6 @@ from typing import (
     Sequence,
     AsyncGenerator,
     Callable,
-    Mapping,
     Iterator,
     overload,
 )


### PR DESCRIPTION
Hi, and thanks for sharing the source.

`Mapping` module was imported twice in `foamlib/_cases.py`.