### PR TITLE
Upgrade dependency pyparsing from >=3 to >=3.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "aioshutil>=1,<2",
     "numpy>=1.25.0,<3; python_version>='3.10'",
     "numpy>=1,<3",
-    "pyparsing>=3,<4",
+    "pyparsing>=3.1.2,<4",
     "typing-extensions>=4,<5; python_version<'3.11'",
 ]
 


### PR DESCRIPTION
Recently I reinstalled the foamlib environment, and pip automatically installed foamlib==0.8.1 and pyparsing==3.1.1 for me, after which foamlib crashed. Here are the steps to reproduce this:
```bash
> conda create -n pyparsing_version_test python=3.12
> conda activate pyparsing_version_test
> pip install pyparsing==3.1.1
> pip install foamlib
......
Requirement already satisfied: pyparsing<4,>=3 in ~\miniconda3\envs\pyparsing_version_test\lib\site-packages (from foamlib) (3.1.1)
Installing collected packages: numpy, aioshutil, foamlib
Successfully installed aioshutil-1.5 foamlib-0.8.1 numpy-2.2.0
> python
Python 3.12.8 | packaged by Anaconda, Inc. | (main, Dec 11 2024, 16:48:34) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import foamlib
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\__init__.py", line 5, in <module>
    from ._cases import (
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_cases\__init__.py", line 1, in <module>
    from ._async import AsyncFoamCase
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_cases\_async.py", line 27, in <module>
    from ._base import FoamCaseBase
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_cases\_base.py", line 14, in <module>
    from .._files import FoamFieldFile, FoamFile
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_files\__init__.py", line 1, in <module>
    from ._files import FoamFieldFile, FoamFile
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_files\_files.py", line 19, in <module>
    from ._io import FoamFileIO
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_files\_io.py", line 13, in <module>
    from ._parsing import Parsed
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_files\_parsing.py", line 264, in <module>
    _Tensor.SCALAR.parser()
  File "~\miniconda3\envs\pyparsing_version_test\Lib\site-packages\foamlib\_files\_parsing.py", line 84, in parser
    return common.ieee_float
           ^^^^^^^^^^^^^^^^^
AttributeError: type object 'pyparsing_common' has no attribute 'ieee_float'
```


According to https://github.com/pyparsing/pyparsing/discussions/545, pyparsing introduced `common.ieee_float` only after version 3.1.2, so using a lower version of pyparsing would make `import foamlib` fail. 

This PR modifies the pyproject.toml file to upgrade the minimal version of pyparsing.