### PR TITLE
Revise article

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -8,6 +8,42 @@
   doi = {10.1016/j.cpc.2021.108143}
 }
 
+@software{fluidfoam,
+  author       = {CyrilleBonamy and
+                  jchauchat and
+                  QuentinClemencot and
+                  Eduard Puig Montellà and
+                  Patrick Höhn and
+                  mathieu7an and
+                  AlixBernard and
+                  Gabriel Gonçalves and
+                  MarieSkorlic and
+                  gnikit and
+                  remichassagne},
+  title        = {fluiddyn/fluidfoam: v0.2.9},
+  month        = feb,
+  year         = 2025,
+  publisher    = {Zenodo},
+  version      = {v0.2.9},
+  doi          = {10.5281/zenodo.14893673},
+  url          = {https://doi.org/10.5281/zenodo.14893673},
+  swhid        = {swh:1:dir:c1288b7b9b94c172b8e578b6bdedac6e72586807
+                   ;origin=https://doi.org/10.5281/zenodo.6453089;vis
+                   it=swh:1:snp:0532d90e1bca63889bb140429d94b96602c50
+                   8f6;anchor=swh:1:rel:3ef7cc12c97a58813c35cd8ce9be3
+                   4088c01dee8;path=fluiddyn-fluidfoam-65de672
+                  },
+}
+
+@misc{fluidsimfoam,
+  author = {Pierre Augier and Pooria Danaeifar},
+  title = {{fluidsimfoam}: {Python} framework for {OpenFOAM}},
+  year = {2025},
+  publisher = {Heptapod},
+  journal = {Heptapod repository},
+  url = {https://foss.heptapod.net/fluiddyn/fluidsimfoam}
+}
+
 @misc{mypy,
   author = {Lehtosalo, Jukka},
   title = {{mypy}: Optional static typing for Python},
@@ -26,6 +62,15 @@
   pages = {357--362},
   year = {2020},
   doi = {10.1038/s41586-020-2649-2}
+}
+
+@misc{ofpp,
+  author = {Xu Xianghua},
+  title = {{Ofpp}: {OpenFOAM Python Parser}},
+  year = {2023},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  url = {https://github.com/xu-xianghua/ofpp}
 }
 
 @misc{openfoam-app,


### PR DESCRIPTION
As part of https://github.com/openjournals/joss-reviews/issues/7633, make the following proposed changes to the paper.

From https://github.com/gerlero/foamlib/issues/316#issuecomment-2643349985

- [x] PAPER: Comment on why an external parser was written instead of C++ bindings for OpenFOAM's own parser.
- [x] PAPER: Mention that looping over a `TimeDirectory` will iterate over the reconstructed time folders.
- [x] PAPER: soften language on statement of what files `FoamFile` can parse & refer readers to `FoamFile` API docs.
- [x] PAPER: fix inconsistency `numpy.ndarray` vs `np.ndarray`.

From https://github.com/gerlero/foamlib/issues/317#issuecomment-2695218940:

- [x] PAPER: mention other OpenFOAM-related Python packages in the statement of need, including `fluidfoam` and `fluidsimfoam`.

From https://github.com/gerlero/foamlib/issues/318#issuecomment-2643393365:

- [x] PAPER: mention hardware used to measure the reported speedup.