### PR TITLE
Fix/ Boolean abbreviations get evaluated in keyword context

### DIFF
--- a/foamlib/_files/_parsing.py
+++ b/foamlib/_files/_parsing.py
@@ -334,14 +334,10 @@ _SWITCH = (
     Keyword("yes", _IDENTBODYCHARS)
     | Keyword("true", _IDENTBODYCHARS)
     | Keyword("on", _IDENTBODYCHARS)
-    | Keyword("y", _IDENTBODYCHARS)
-    | Keyword("t", _IDENTBODYCHARS)
 ).set_parse_action(lambda: True) | (
     Keyword("no", _IDENTBODYCHARS)
     | Keyword("false", _IDENTBODYCHARS)
     | Keyword("off", _IDENTBODYCHARS)
-    | Keyword("n", _IDENTBODYCHARS)
-    | Keyword("f", _IDENTBODYCHARS)
 ).set_parse_action(lambda: False)
 _DIMENSIONS = (
     Literal("[").suppress() + common.number[0, 7] + Literal("]").suppress()

--- a/tests/test_files/test_dumps.py
+++ b/tests/test_files/test_dumps.py
@@ -89,7 +89,7 @@ def test_serialize_data() -> None:
         )
         == b"hex (0 1 2 3 4 5 6 7) (1 1 1) simpleGrading (1 1 1)"
     )
-    assert dumps([("a", "b"), ("c", "d")]) == b"(a b; c d;)"
+    assert dumps([("a", "b"), ("c", "d"), ("n", "no"), ("y", "yes")]) == b"(a b; c d; n no; y yes;)"
     assert dumps([("a", {"b": "c"}), ("d", {"e": "g"})]) == b"(a {b c;} d {e g;})"
     assert dumps([("a", [0, 1, 2]), ("b", {})]) == b"(a (0 1 2); b {})"
     assert dumps(["water", "oil", "mercury", "air"]) == b"(water oil mercury air)"
@@ -103,8 +103,8 @@ def test_serialize_file() -> None:
         == b"{FoamFile {version 2.0; format ascii; class dictionary;}} 1.0"
     )
     assert (
-        FoamFile.dumps({"a": "b", "c": "d"})
-        == b"{FoamFile {version 2.0; format ascii; class dictionary;}} a b; c d;"
+        FoamFile.dumps({"a": "b", "c": "d", "n": "no", "y": "yes"})
+        == b"{FoamFile {version 2.0; format ascii; class dictionary;}} a b; c d; n no; y yes;"
     )
     assert (
         FoamFile.dumps({"internalField": [[1, 2, 3], [4, 5, 6]]})

--- a/tests/test_files/test_dumps.py
+++ b/tests/test_files/test_dumps.py
@@ -89,7 +89,10 @@ def test_serialize_data() -> None:
         )
         == b"hex (0 1 2 3 4 5 6 7) (1 1 1) simpleGrading (1 1 1)"
     )
-    assert dumps([("a", "b"), ("c", "d"), ("n", "no"), ("y", "yes")]) == b"(a b; c d; n no; y yes;)"
+    assert (
+        dumps([("a", "b"), ("c", "d"), ("n", "no"), ("y", "yes")])
+        == b"(a b; c d; n no; y yes;)"
+    )
     assert dumps([("a", {"b": "c"}), ("d", {"e": "g"})]) == b"(a {b c;} d {e g;})"
     assert dumps([("a", [0, 1, 2]), ("b", {})]) == b"(a (0 1 2); b {})"
     assert dumps(["water", "oil", "mercury", "air"]) == b"(water oil mercury air)"


### PR DESCRIPTION
This is a tiny PR to fix a minor bug with situations where `n, f, y, or t` appear as a **keyword** in a key-val tuple.

**Original behavior:**

The unit tests:
```python
    assert dumps([("a", "b"), ("c", "d"), ("n", "no"), ("y", "yes")]) == b"(a b; c d; n no; y yes;)"
    assert (
        FoamFile.dumps({"a": "b", "c": "d", "n": "no", "y": "yes"})
        == b"{FoamFile {version 2.0; format ascii; class dictionary;}} a b; c d; n no; y yes;"
    )
```
fail, saying, respectively:
```
- b'(a b; c d; n no; y yes;)'
+ b'(a b; c d; no no; yes yes;)'
-----------------------------------------
-  b'{FoamFile {version 2.0; format ascii; class dictionary;}} a b; c d; n no; y yes;'
+  b'{FoamFile {version 2.0; format ascii; class dictionary;}} a b; c d; no no; yes yes;'
```

In short, "n" and "y" get normalized even if they are keywords. This gets annoying for example when controlling nProcs settings for decomposition methods is desired...

**Suggested solution:**
- Don't consider these single-char abbreviations as booleans. **Effects:** All unit tests should still pass; these abbreviations are not supported by OpenFOAM so this should be alright.

**An alternative solution** that I haven't had time to try is to dig around `normalize_data/normalize_keyword` to skip normalizing the first element in a tuple but that would be hard to distinguish because  of OpenFOAM's ambiguous syntax: without full context, the first "n" in `("n" "n")`  cannot be judged to be a keyword or a data element.