### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,4 +1,6 @@
 name: Update Docker Hub description
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/foamlib/security/code-scanning/1](https://github.com/gerlero/foamlib/security/code-scanning/1)

The best fix is to explicitly set the minimal required permissions for the workflow or this specific job. Since the job needs only to read repository contents (for example, to access the README.md), we set `contents: read`. Add a `permissions:` key either at the workflow root (to apply to all jobs) or at the `dockerhub-description` job level (to apply only to that job). Since there is only one job, either location is fine, but putting it at the root level has the advantage of enforcing it if more jobs are later added.  
**Change:**  
Insert the following block near the top of the workflow file (e.g., after `name`):  
```yaml
permissions:
  contents: read
```

No imports or further changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
