### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/foamlib/security/code-scanning/2](https://github.com/gerlero/foamlib/security/code-scanning/2)

The best fix is to add a `permissions` key as close to the top of the workflow as possible, so it will apply to all jobs by default. For this workflow, adding the following block at the top level (before `jobs:`) with the minimal permissions required is sufficient and will have no negative effect. If none of the jobs require write access to repository content or other resources, `contents: read` is the correct and safest selection. To implement:
- Insert a `permissions:` block (usually after `name:` or after `on:`) at the root level of `.github/workflows/ci.yml`.
- Set `contents: read`.
No new methods, imports, or further changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
