### PR TITLE
Modify scipy-stubs dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ typing = [
     {include-group = "preprocessing"},
     {include-group = "postprocessing"},
     "pandas-stubs",
-    "scipy-stubs; python_version>='3.10'",
+    "scipy-stubs",
     "ty",
     "types-defusedxml",
 ]


### PR DESCRIPTION
Updated scipy-stubs dependency to remove Python version restriction.