### PR TITLE
Enable fast-path parsing of top-level ASCII one-dimensional float lists

### DIFF
--- a/src/foamlib/_files/_parsing/_grammar.py
+++ b/src/foamlib/_files/_parsing/_grammar.py
@@ -150,8 +150,9 @@ DATA <<= _DATA_ENTRY[1, ...].set_parse_action(
 
 _STANDALONE_DATA_ENTRY = (
     ASCIINumericList(dtype=int)
-    | ASCIIFacesLikeList()
+    | ASCIINumericList(dtype=float)
     | ASCIINumericList(dtype=float, elshape=(3,))
+    | ASCIIFacesLikeList()
     | (
         (
             binary_numeric_list(dtype=np.int32)

--- a/src/foamlib/_files/_serialization.py
+++ b/src/foamlib/_files/_serialization.py
@@ -187,9 +187,9 @@ def normalized(
                 return data  # ty: ignore[invalid-return-type]
             return data.astype(float, copy=False)  # ty: ignore[possibly-missing-attribute]
 
-        # Other possible numeric standalone data (n integers)
-        case [Integral(), *rest], () if not isinstance(data, tuple) and all(
-            isinstance(r, Integral) for r in rest
+        # Other possible numeric standalone data (n integers or floats)
+        case [Real(), *rest], () if not isinstance(data, tuple) and all(
+            isinstance(r, Real) for r in rest
         ):
             return normalized(np.asarray(data), keywords=keywords, format_=format_)
 

--- a/tests/test_files/test_dumps.py
+++ b/tests/test_files/test_dumps.py
@@ -184,6 +184,7 @@ def test_serialize_file() -> None:
         == b"FoamFile {version 2.0; format ascii; class dictionary;} (1 2 3 4 5 6)"
     )
     assert FoamFile.dumps([1, 2, 3], ensure_header=False) == b"(1 2 3)"
+    assert FoamFile.dumps([1.0, 2, 3], ensure_header=False) == b"(1.0 2.0 3.0)"
     assert (
         FoamFile.dumps(
             {

--- a/tests/test_files/test_parsing/test_basic.py
+++ b/tests/test_files/test_parsing/test_basic.py
@@ -22,7 +22,7 @@ def test_parse_value() -> None:
     lst = ParsedFile(b"(1 2 3)")[()]
     assert isinstance(lst, np.ndarray)
     assert np.array_equal(lst, [1, 2, 3])
-    lst = ParsedFile(b"(1.0 2 3)")[()]
+    lst = ParsedFile(b"list (1.0 2 3);")[("list",)]
     assert isinstance(lst, list)
     assert lst == [1.0, 2, 3]
     assert isinstance(lst[0], float)
@@ -34,35 +34,50 @@ def test_parse_value() -> None:
     assert np.array_equal(field, [1, 2, 3])
     field = ParsedFile(b"nonuniform List<scalar> 2(1 2)")[()]
     assert isinstance(field, np.ndarray)
-    assert np.array_equal(field, [1, 2])
+    assert field.dtype == float
+    assert np.array_equal(field, [1.0, 2.0])
+    field = ParsedFile(b"nonuniform List<scalar> 2(1/*comment*/2)")[()]
+    assert isinstance(field, np.ndarray)
+    assert field.dtype == float
+    assert np.array_equal(field, [1.0, 2.0])
     field = ParsedFile(b"nonuniform List<scalar> 2{1}")[()]
     assert isinstance(field, np.ndarray)
-    assert np.array_equal(field, [1, 1])
+    assert field.dtype == float
+    assert np.array_equal(field, [1.0, 1.0])
     field = ParsedFile(b"nonuniform List<symmTensor> 0()")[()]
     assert isinstance(field, np.ndarray)
+    assert field.dtype == float
     assert field.shape == (0, 6)
     field = ParsedFile(b"nonuniform List<tensor> ()")[()]
     assert isinstance(field, np.ndarray)
+    assert field.dtype == float
     assert field.shape == (0, 9)
-    lst = ParsedFile(b"3(1 2 3)")[()]
-    assert isinstance(lst, np.ndarray)
-    assert np.array_equal(lst, [1, 2, 3])
-    lst = ParsedFile(b"2((1 2 3) (4 5 6))")[()]
-    assert isinstance(lst, np.ndarray)
+    arr = ParsedFile(b"3(1 2 3)")[()]
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == int
+    assert np.array_equal(arr, [1, 2, 3])
+    arr = ParsedFile(b"3(1.0 2 3)")[()]
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == float
+    assert np.array_equal(arr, [1.0, 2.0, 3.0])
+    arr = ParsedFile(b"2((1 2 3) (4 5 6))")[()]
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == float
     assert np.array_equal(
-        lst,
+        arr,
         [
-            [1, 2, 3],
-            [4, 5, 6],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
         ],
     )
-    lst = ParsedFile(b"2((1\n2 3)\t(4 5 6))")[()]
-    assert isinstance(lst, np.ndarray)
+    arr = ParsedFile(b"2((1\n2 3)\t(4 5 6))")[()]
+    assert isinstance(arr, np.ndarray)
+    assert arr.dtype == float
     assert np.array_equal(
-        lst,
+        arr,
         [
-            [1, 2, 3],
-            [4, 5, 6],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
         ],
     )
     lst = ParsedFile(b"2(3(1 2 3) 4(4 5 6 7))")[()]


### PR DESCRIPTION
Fixes #667 