### PR TITLE
Refactor parsing of numeric ASCII lists-of-lists

### DIFF
--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -378,7 +378,7 @@ class _ASCIINumericListParser(Generic[_DType, _ElShape]):
             ) from e
 
         try:
-            ret = np.fromstring(data, sep=" ", dtype=self._dtype)
+            ret = np.array(data.split(), dtype=self._dtype)
         except ValueError as e:
             raise ParseError(
                 contents,
@@ -414,140 +414,112 @@ _parse_ascii_symm_tensor_list = _ASCIINumericListParser(dtype=float, elshape=(6,
 _parse_ascii_tensor_list = _ASCIINumericListParser(dtype=float, elshape=(9,))
 
 
-_THREE_FACE_LIKE = re.compile(
-    rb"3(?:"
-    + _SKIP.pattern
-    + rb")?\((?:"
-    + _SKIP.pattern
-    + rb")?(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"(?:"
-    + _SKIP.pattern
-    + rb"))(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"(?:"
-    + _SKIP.pattern
-    + rb"))(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb")(?:"
-    + _SKIP.pattern
-    + rb")?\)"
+_SUB_LIST_LIKE = re.compile(
+    rb"(?:" + _POSSIBLE_INTEGER.pattern + rb")(?:" + _SKIP.pattern + rb")?\([^()]*?\)"
 )
-_UNCOMMENTED_THREE_FACE_LIKE = re.compile(
-    rb"3\s*\(\s*(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"\s*)(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"\s*)(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb")\s*\)",
+_UNCOMMENTED_SUB_LIST_LIKE = re.compile(
+    rb"(?:" + _POSSIBLE_INTEGER.pattern + rb")\s*\([^()]*?\)",
     re.ASCII,
 )
-_FOUR_FACE_LIKE = re.compile(
-    rb"4(?:"
-    + _SKIP.pattern
-    + rb")?\((?:"
-    + _SKIP.pattern
-    + rb")?(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"(?:"
-    + _SKIP.pattern
-    + rb"))(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"(?:"
-    + _SKIP.pattern
-    + rb"))(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"(?:"
-    + _SKIP.pattern
-    + rb"))(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb")(?:"
-    + _SKIP.pattern
-    + rb")?\)"
-)
-_UNCOMMENTED_FOUR_FACE_LIKE = re.compile(
-    rb"4\s*\(\s*(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"\s*)(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"\s*)(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb"\s*)(?:"
-    + _POSSIBLE_INTEGER.pattern
-    + rb")\s*\)",
-    re.ASCII,
-)
-_FACES_LIKE_LIST = re.compile(
+_LIST_OF_LISTS_LIKE = re.compile(
     rb"(?:(?:"
     + _SKIP.pattern
-    + rb")?(?:"
-    + _THREE_FACE_LIKE.pattern
-    + rb"|"
-    + _FOUR_FACE_LIKE.pattern
-    + rb"))*(?:"
+    + rb")?"
+    + _SUB_LIST_LIKE.pattern
+    + rb")*(?:"
     + _SKIP.pattern
     + rb")?\)"
 )
-_UNCOMMENTED_FACES_LIKE_LIST = re.compile(
-    rb"(?:\s*(?:"
-    + _UNCOMMENTED_THREE_FACE_LIKE.pattern
-    + rb"|"
-    + _UNCOMMENTED_FOUR_FACE_LIKE.pattern
-    + rb"))*\s*\)",
+_UNCOMMENTED_LIST_OF_LISTS_LIKE = re.compile(
+    rb"(?:\s*" + _UNCOMMENTED_SUB_LIST_LIKE.pattern + rb")*\s*\)",
     re.ASCII,
 )
+
+
+class _ASCIINumericListListParser(Generic[_DType]):
+    def __init__(self, *, dtype: type[_DType]) -> None:
+        self._dtype = dtype
+
+    def __call__(
+        self,
+        contents: bytes | bytearray,
+        pos: int,
+        *,
+        empty_ok: bool = False,
+    ) -> tuple[list[np.ndarray[tuple[int], np.dtype[np.float64 | np.int64]]], int]:
+        try:
+            count, pos = _parse_number(contents, pos, target=int)
+        except ParseError:
+            count = None
+        else:
+            if count < 0:
+                raise ParseError(contents, pos, expected="non-negative list count")
+            pos = _skip(contents, pos)
+
+        pos = _expect(contents, pos, b"(")
+
+        if match := _UNCOMMENTED_LIST_OF_LISTS_LIKE.match(contents, pos):
+            data = contents[pos : match.end() - 1]
+            pos = match.end()
+
+        elif match := _LIST_OF_LISTS_LIKE.match(contents, pos):
+            data = contents[pos : match.end() - 1]
+            pos = match.end()
+
+            data = _COMMENTS.sub(b" ", data)
+
+        if not match:
+            raise ParseError(contents, pos, expected="numeric list of lists")
+
+        data = data.replace(b"(", b" ").replace(b")", b" ")
+        try:
+            data = data.decode("ascii")
+        except UnicodeDecodeError as e:
+            raise ParseError(contents, pos, expected="numeric list of lists") from e
+
+        # Resolve to explicit numpy dtype to ensure platform-consistent bit width
+        # (Python's `int` maps to int32 on Windows with numpy, but OpenFOAM labels
+        # should always be 64-bit when read in ASCII).
+        np_dtype: type = np.int64 if self._dtype is int else np.float64
+
+        # Use np.array(data.split()) rather than np.fromstring to:
+        #   - avoid DeprecationWarning from np.fromstring when data contains
+        #     trailing non-numeric content (which we use to detect type mismatch)
+        #   - raise ValueError immediately on any non-parseable token (e.g. a
+        #     float '0.1' when dtype=np.int64), which is caught below as ParseError
+        try:
+            values = np.array(data.split(), dtype=np_dtype)
+        except ValueError as e:
+            raise ParseError(contents, pos, expected="numeric list of lists") from e
+
+        ret: list[np.ndarray] = []
+        i = 0
+        while i < len(values):
+            n = int(values[i])
+            ret.append(values[i + 1 : i + n + 1])
+            i += n + 1
+
+        if count is None:
+            if not empty_ok and len(ret) == 0:
+                raise ParseError(
+                    contents, pos, expected="non-empty numeric list of lists"
+                )
+        elif len(ret) != count:
+            raise ParseError(
+                contents, pos, expected=f"{count} elements (got {len(ret)})"
+            )
+
+        return ret, pos
+
+
+_parse_ascii_integer_list_list = _ASCIINumericListListParser(dtype=int)
+_parse_ascii_float_list_list = _ASCIINumericListListParser(dtype=float)
 
 
 def _parse_ascii_faces_like_list(
     contents: bytes | bytearray, pos: int
-) -> tuple[list[np.ndarray[tuple[Literal[3, 4]], np.dtype[np.int64]]], int]:
-    try:
-        count, pos = _parse_number(contents, pos, target=int)
-    except ParseError:
-        count = None
-    else:
-        if count < 0:
-            raise ParseError(contents, pos, expected="non-negative list count")
-        pos = _skip(contents, pos)
-
-    pos = _expect(contents, pos, b"(")
-
-    if match := _UNCOMMENTED_FACES_LIKE_LIST.match(contents, pos):
-        data = contents[pos : match.end() - 1]
-        pos = match.end()
-
-    elif match := _FACES_LIKE_LIST.match(contents, pos):
-        data = contents[pos : match.end() - 1]
-        pos = match.end()
-
-        data = _COMMENTS.sub(b" ", data)
-
-    if not match:
-        raise ParseError(contents, pos, expected="faces-like list")
-
-    data = data.replace(b"(", b" ").replace(b")", b" ")
-    try:
-        data = data.decode("ascii")
-    except UnicodeDecodeError as e:
-        raise ParseError(contents, pos, expected="faces-like list") from e
-
-    try:
-        values = np.fromstring(data, sep=" ", dtype=int)
-    except ValueError as e:
-        raise ParseError(contents, pos, expected="faces-like list") from e
-
-    ret: list[np.ndarray] = []
-    i = 0
-    while i < len(values):
-        n = values[i]
-        ret.append(values[i + 1 : i + n + 1])
-        i += n + 1
-
-    if count is not None and len(ret) != count:
-        raise ParseError(contents, pos, expected=f"{count} faces (got {len(ret)})")
-
-    return ret, pos
+) -> tuple[list[np.ndarray[tuple[int], np.dtype[np.int64]]], int]:
+    return _parse_ascii_integer_list_list(contents, pos)
 
 
 def _parse_binary_numeric_list(
@@ -916,6 +888,10 @@ def _parse_standalone_data_entry(
         return _parse_ascii_vector_list(contents, pos)
     with contextlib.suppress(ParseError):
         return _parse_ascii_faces_like_list(contents, pos)
+    # _parse_ascii_float_list_list is tried after faces-like (integer list-of-lists)
+    # to handle sparse/non-uniform float lists that look like n(v1 v2 ...) per row.
+    with contextlib.suppress(ParseError):
+        return _parse_ascii_float_list_list(contents, pos)
 
     try:
         entry1, pos1 = _parse_data(contents, pos)

--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -434,6 +434,10 @@ _UNCOMMENTED_LIST_OF_LISTS_LIKE = re.compile(
     rb"(?:\s*" + _UNCOMMENTED_SUB_LIST_LIKE.pattern + rb")*\s*\)",
     re.ASCII,
 )
+_SUBLIST_CAPTURE = re.compile(
+    rb"(" + _POSSIBLE_INTEGER.pattern + rb")\s*\(([^()]*?)\)",
+    re.ASCII,
+)
 
 
 class _ASCIINumericListListParser(Generic[_DType]):
@@ -471,33 +475,58 @@ class _ASCIINumericListListParser(Generic[_DType]):
         if not match:
             raise ParseError(contents, pos, expected="numeric list of lists")
 
-        data = data.replace(b"(", b" ").replace(b")", b" ")
-        try:
-            data = data.decode("ascii")
-        except UnicodeDecodeError as e:
-            raise ParseError(contents, pos, expected="numeric list of lists") from e
-
         # Resolve to explicit numpy dtype to ensure platform-consistent bit width
         # (Python's `int` maps to int32 on Windows with numpy, but OpenFOAM labels
         # should always be 64-bit when read in ASCII).
         np_dtype: type = np.int64 if self._dtype is int else np.float64
 
-        # Use np.array(data.split()) rather than np.fromstring to:
-        #   - avoid DeprecationWarning from np.fromstring when data contains
-        #     trailing non-numeric content (which we use to detect type mismatch)
-        #   - raise ValueError immediately on any non-parseable token (e.g. a
-        #     float '0.1' when dtype=np.int64), which is caught below as ParseError
-        try:
-            values = np.array(data.split(), dtype=np_dtype)
-        except ValueError as e:
-            raise ParseError(contents, pos, expected="numeric list of lists") from e
-
         ret: list[np.ndarray] = []
-        i = 0
-        while i < len(values):
-            n = int(values[i])
-            ret.append(values[i + 1 : i + n + 1])
-            i += n + 1
+
+        if count is None:
+            # No outer count: validate each sub-list individually so a wrong
+            # inline count (e.g. "2(1 2 3)") is caught immediately.
+            # In practice OpenFOAM only omits the outer count for short lists,
+            # so the per-sublist Python loop is not a performance concern.
+            for m in _SUBLIST_CAPTURE.finditer(data):
+                n = int(m.group(1))
+                if n < 0:
+                    raise ParseError(contents, pos, expected="numeric list of lists")
+                try:
+                    inner = np.array(
+                        m.group(2).decode("ascii").split(), dtype=np_dtype
+                    )
+                except (ValueError, UnicodeDecodeError) as e:
+                    raise ParseError(
+                        contents, pos, expected="numeric list of lists"
+                    ) from e
+                if len(inner) != n:
+                    raise ParseError(contents, pos, expected="numeric list of lists")
+                ret.append(inner)
+        else:
+            # Outer count present: use the fast flat-array approach.
+            # The outer count check below catches any net sublist-count mismatch.
+            # The in-loop guards prevent crashes on negative or truncated counts.
+
+            # Use np.array(data.split()) rather than np.fromstring to:
+            #   - avoid DeprecationWarning from np.fromstring when data contains
+            #     trailing non-numeric content (which we use to detect type mismatch)
+            #   - raise ValueError immediately on any non-parseable token (e.g. a
+            #     float '0.1' when dtype=np.int64), which is caught below as ParseError
+            data_flat = data.replace(b"(", b" ").replace(b")", b" ")
+            try:
+                values = np.array(data_flat.decode("ascii").split(), dtype=np_dtype)
+            except (ValueError, UnicodeDecodeError) as e:
+                raise ParseError(
+                    contents, pos, expected="numeric list of lists"
+                ) from e
+
+            i = 0
+            while i < len(values):
+                n = int(values[i])
+                if n < 0 or i + n + 1 > len(values):
+                    raise ParseError(contents, pos, expected="numeric list of lists")
+                ret.append(values[i + 1 : i + n + 1])
+                i += n + 1
 
         if count is None:
             if not empty_ok and len(ret) == 0:

--- a/tests/test_files/test_parsing/test_poly_face_list.py
+++ b/tests/test_files/test_parsing/test_poly_face_list.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 from foamlib import FoamFile
+from foamlib._files._parsing._parser import (
+    ParseError,
+    _parse_ascii_float_list_list,
+    _parse_ascii_integer_list_list,
+)
 
 faces_contents = r"""
 /*--------------------------------*- C++ -*----------------------------------*\
@@ -98,3 +104,76 @@ def test_parse_commented_faces(tmp_path: Path) -> None:
     assert np.array_equal(faces[0], [0, 1, 2])
     assert np.array_equal(faces[1], [3, 4, 5, 6])
     assert np.array_equal(faces[2], [7, 8, 9, 10, 11])
+
+
+# --- Sub-list count validation: no outer count (per-sublist path) ---
+# When no outer count is present OpenFOAM omits it for short lists.
+# The parser validates each n(...) individually in this path.
+
+
+def test_no_outer_count_correct() -> None:
+    ret, _ = _parse_ascii_integer_list_list(b"(\n3(0 1 2)\n4(3 4 5 6)\n5(7 8 9 10 11)\n)", 0)
+    assert [list(s) for s in ret] == [[0, 1, 2], [3, 4, 5, 6], [7, 8, 9, 10, 11]]
+
+
+def test_no_outer_count_zero_length_sublist() -> None:
+    ret, _ = _parse_ascii_integer_list_list(b"(0())", 0, empty_ok=True)
+    assert len(ret) == 1
+    assert len(ret[0]) == 0
+
+
+def test_no_outer_count_overfull_sublist() -> None:
+    """2(1 2 3): count says 2 but 3 values are present."""
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"(2(1 2 3))", 0)
+
+
+def test_no_outer_count_underfull_sublist() -> None:
+    """4(1 2 3): count says 4 but only 3 values are present."""
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"(4(1 2 3))", 0)
+
+
+def test_no_outer_count_overfull_first_correct_second() -> None:
+    """2(1 2 3) 4(10 20 30 40): first sub-list has a wrong count."""
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"(2(1 2 3) 4(10 20 30 40))", 0)
+
+
+def test_no_outer_count_negative_sublist_count() -> None:
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"(-1(0 1 2))", 0)
+
+
+def test_no_outer_count_float_list_overfull_sublist() -> None:
+    """Same validation applies to float list-of-lists."""
+    with pytest.raises(ParseError):
+        _parse_ascii_float_list_list(b"(2(0.1 0.2 0.3))", 0)
+
+
+# --- Sub-list count validation: outer count present (fast-path + guards) ---
+# When an outer count is present the parser uses the fast flat-array loop.
+# The outer count acts as the primary net check; two in-loop guards cover
+# crash scenarios (negative count, data shorter than declared length).
+
+
+def test_outer_count_correct() -> None:
+    ret, _ = _parse_ascii_integer_list_list(b"3\n(\n3(0 1 2)\n4(3 4 5 6)\n5(7 8 9 10 11)\n)", 0)
+    assert [list(s) for s in ret] == [[0, 1, 2], [3, 4, 5, 6], [7, 8, 9, 10, 11]]
+
+
+def test_outer_count_mismatch() -> None:
+    """Outer count says 3 but only 2 sub-lists are present."""
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"3\n(\n4(0 1 2 3)\n4(4 5 6 7)\n)", 0)
+
+
+def test_outer_count_underfull_sublist_crash_guard() -> None:
+    """4(1 2 3): declared length exceeds available data — crash guard triggers."""
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"1\n(\n4(1 2 3)\n)", 0)
+
+
+def test_outer_count_negative_sublist_count_crash_guard() -> None:
+    with pytest.raises(ParseError):
+        _parse_ascii_integer_list_list(b"1\n(\n-1(0 1 2)\n)", 0)

--- a/tests/test_files/test_parsing/test_poly_face_list.py
+++ b/tests/test_files/test_parsing/test_poly_face_list.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import numpy as np
+from foamlib import FoamFile
+
+faces_contents = r"""
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  2206                                  |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       faceList;
+    location    "constant/polyMesh";
+    object      faces;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+3
+(
+3(0 1 2)
+4(3 4 5 6)
+5(7 8 9 10 11)
+)
+
+// ************************************************************************* //
+"""
+
+
+def test_parse_poly_faces(tmp_path: Path) -> None:
+    """Test that ascii faceList with triangles, quads, and pentagons is parsed correctly."""
+    path = tmp_path / "faces"
+    path.write_text(faces_contents)
+
+    file = FoamFile(path)
+    faces = file[None]
+
+    assert len(faces) == 3
+    assert np.array_equal(faces[0], [0, 1, 2])
+    assert np.array_equal(faces[1], [3, 4, 5, 6])
+    assert np.array_equal(faces[2], [7, 8, 9, 10, 11])
+
+
+float_list_list_contents = r"""
+3
+(
+2(0.1 0.2)
+3(0.3 0.4 0.5)
+1(0.6)
+)
+"""
+
+
+def test_parse_float_list_list(tmp_path: Path) -> None:
+    """Test that a standalone ascii numeric list-of-lists with float values is parsed correctly."""
+    path = tmp_path / "floats"
+    path.write_text(float_list_list_contents)
+
+    file = FoamFile(path)
+    data = file[None]
+
+    assert len(data) == 3
+    assert np.allclose(data[0], [0.1, 0.2])
+    assert np.allclose(data[1], [0.3, 0.4, 0.5])
+    assert np.allclose(data[2], [0.6])
+
+
+commented_faces_contents = r"""
+3
+(
+3(0 1 2) // triangle
+4 /* quad */ (3 4 5 6)
+5(
+  7 // comment inside
+  8
+  9
+  10
+  11
+)
+)
+"""
+
+
+def test_parse_commented_faces(tmp_path: Path) -> None:
+    """Test that ascii faceList with inline comments is parsed correctly."""
+    path = tmp_path / "faces_commented"
+    path.write_text(commented_faces_contents)
+
+    file = FoamFile(path)
+    faces = file[None]
+
+    assert len(faces) == 3
+    assert np.array_equal(faces[0], [0, 1, 2])
+    assert np.array_equal(faces[1], [3, 4, 5, 6])
+    assert np.array_equal(faces[2], [7, 8, 9, 10, 11])


### PR DESCRIPTION
## Summary

Extends the ASCII numeric list-of-lists parser to support sub-lists of arbitrary length, fixing slow parsing of `faceList` fields in polyMesh files that contain polygonal faces with 5 or more vertices.

Addresses the reviewer concern about missing inline count validation by introducing a hybrid validation strategy that keeps the performance of the fast path for large production meshes.

---

## Background

OpenFOAM stores face connectivity in ASCII format as a list-of-lists where each entry is prefixed by its element count:

```
80867
(
4(0 1 20587 20586)
5(21224 21223 21284 21285 21286)
6(21270 21271 21272 21273 21274 21275)
...
)
```

The previous parser only recognised sub-lists of fixed length 3 or 4 (matching vector and tensor shapes), causing any face with 5+ vertices to fall through to the generic slow-path parser — making even small poly meshes extremely slow to parse.

---

## Changes

### Arbitrary sub-list length (original fix, `ae73c6f`)

Replaced the hardcoded shape check with a general loop that reads each inline count `n` and slices the next `n` values from the flattened array.

### Inline count validation (this update)

The reviewer correctly noted that the flat-array approach silently accepts malformed input like `2(1 2 3)` (count says 2, but 3 values are present). After stripping parentheses, the extra value bleeds into the stream and is misread as the count of the next sub-list, potentially returning wrong data without raising an error.

The fix uses a **hybrid strategy** based on whether an outer count is present in the file:

#### `count is None` — per-sublist path (fully validating)

When no outer element count is written, the parser iterates with `_SUBLIST_CAPTURE.finditer` and validates each `n(...)` block individually:

```python
for m in _SUBLIST_CAPTURE.finditer(data):
    n = int(m.group(1))
    if n < 0:
        raise ParseError(...)
    inner = np.array(m.group(2).decode("ascii").split(), dtype=np_dtype)
    if len(inner) != n:
        raise ParseError(...)
    ret.append(inner)
```

Any mismatch between the declared count and the actual content raises immediately.

#### `count is not None` — fast flat-array path (production path)

When an outer count is present, the original flat-array approach is kept for performance. Two in-loop guards cover crash scenarios; the outer count check acts as the primary correctness net:

```python
while i < len(values):
    n = int(values[i])
    if n < 0 or i + n + 1 > len(values):   # crash guard
        raise ParseError(...)
    ret.append(values[i + 1 : i + n + 1])
    i += n + 1
# ...
elif len(ret) != count:
    raise ParseError(...)   # net mismatch
```

#### Rationale for the split

OpenFOAM omits the outer count only for short lists (roughly ≤ 20 elements). For all large production face lists the outer count is always present, so:

- **Performance where it matters** (large meshes): the fast flat-array loop is used, with no per-sublist Python overhead.
- **Full correctness where performance is free** (short uncounted lists): each sub-list is validated independently.
- **Known residual limitation on the fast path**: an overfull sub-list whose extra values happen to form valid phantom sub-lists that sum to the correct outer count would not be detected. Given that vertex indices are large unsigned integers, the probability of this occurring in practice in a real mesh file is negligible.

---

## Tests added

Eleven new tests in `tests/test_files/test_parsing/test_poly_face_list.py`, split by path:

| Test | Path | Expected |
|---|---|---|
| Correct arbitrary-length sub-lists (3/4/5 vertices) | both | success |
| Zero-count sub-list `0()` | no outer count | success |
| Overfull: `2(1 2 3)` | no outer count | `ParseError` |
| Underfull: `4(1 2 3)` | no outer count | `ParseError` |
| Overfull first, correct second: `2(1 2 3) 4(10 20 30 40)` | no outer count | `ParseError` |
| Negative sub-list count: `-1(0 1 2)` | no outer count | `ParseError` |
| Float list-of-lists overfull sub-list | no outer count | `ParseError` |
| Outer count mismatch (declared 3, got 2 sub-lists) | outer count | `ParseError` |
| Underfull sub-list exceeds available data (crash guard) | outer count | `ParseError` |
| Negative sub-list count (crash guard) | outer count | `ParseError` |
