### PR TITLE
Allow unquoted file paths as word tokens (fixes #761)

### DIFF
--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -39,11 +39,6 @@ _ElShape = TypeVar(
 _Output = TypeVar("_Output", FileDict, Data, StandaloneData, str)
 
 _IS_TOKEN_START = [False] * 256
-# A word/token may start with a letter, underscore, '#'/'$' (directives and
-# variable expansions), or with '.'/'/' so that file paths (e.g.
-# "./../mech.yaml" or "/abs/path") are read as a single unquoted word, matching
-# OpenFOAM, which accepts such paths unquoted. Numbers are parsed before tokens,
-# so genuine floats like ".5" or "-.5" are still parsed as numbers.
 for c in b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_#$./":
     _IS_TOKEN_START[c] = True
 

--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -39,7 +39,12 @@ _ElShape = TypeVar(
 _Output = TypeVar("_Output", FileDict, Data, StandaloneData, str)
 
 _IS_TOKEN_START = [False] * 256
-for c in b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_#$":
+# A word/token may start with a letter, underscore, '#'/'$' (directives and
+# variable expansions), or with '.'/'/' so that file paths (e.g.
+# "./../mech.yaml" or "/abs/path") are read as a single unquoted word, matching
+# OpenFOAM, which accepts such paths unquoted. Numbers are parsed before tokens,
+# so genuine floats like ".5" or "-.5" are still parsed as numbers.
+for c in b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_#$./":
     _IS_TOKEN_START[c] = True
 
 _IS_TOKEN_CONTINUATION = _IS_TOKEN_START.copy()

--- a/tests/test_files/test_parsing/test_issue_761.py
+++ b/tests/test_files/test_parsing/test_issue_761.py
@@ -1,0 +1,64 @@
+"""
+Test case for issue #761: writing/reading an unquoted file-path string.
+
+OpenFOAM accepts file paths (e.g. ``./../mech.yaml`` or ``/abs/path``) written
+to dictionaries unquoted, but foamlib used to reject them because a word/token
+was not allowed to start with ``.`` or ``/``. These paths now parse as a single
+string and round-trip unchanged.
+"""
+
+from pathlib import Path
+
+import pytest
+from foamlib import FoamFile
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "./../mechanisms/H2/CRECK/syngas-creck.yaml",
+        "/abs/path/to/file.yaml",
+        "mech/H2/x.yaml",
+        ".foo",
+        "./",
+    ],
+)
+def test_unquoted_path_parses_as_string(path: str) -> None:
+    assert FoamFile.loads(f"p {path};".encode()) == {"p": path}
+
+
+def test_unquoted_path_dumps_round_trip() -> None:
+    path = "./../mechanisms/H2/CRECK/syngas-creck.yaml"
+    assert FoamFile.loads(FoamFile.dumps(path)) == path
+
+
+def test_add_path_entry_round_trips(tmp_path: Path) -> None:
+    """The original reporter scenario: write path entries, then read them back."""
+    data = {
+        "path": "./../mechanisms/H2/CRECK/syngas-creck.yaml",
+        "absPath": "/abs/x.yaml",
+        "note": "plain",
+    }
+
+    file_path = tmp_path / "my_file"
+    with FoamFile(file_path) as file:
+        for k, v in data.items():
+            file.add(k, v)
+
+    read_back = FoamFile(file_path)
+    for k, v in data.items():
+        assert read_back[k] == v
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (".5", 0.5),
+        ("-.5", -0.5),
+        ("1.5e-3", 0.0015),
+        ("5.", 5.0),
+    ],
+)
+def test_floats_still_parse_as_numbers(text: str, expected: float) -> None:
+    """Allowing '.'/'/' word starts must not turn genuine floats into strings."""
+    assert FoamFile.loads(f"x {text};".encode()) == {"x": expected}


### PR DESCRIPTION
Fixes #761.

## Problem

Writing a dictionary entry whose value is an unquoted file path raised an error, even though OpenFOAM accepts such paths:

```python
with FoamFile("my_file") as f:
    f.add("path", "./../mechanisms/H2/CRECK/syngas-creck.yaml")
# ValueError: invalid string: "./../mechanisms/H2/CRECK/syngas-creck.yaml"
```

The same path also failed on read (`FoamFileDecodeError`).

## Root cause

A word/token was only allowed to **start** with a letter, `_`, `#` or `$` (`_IS_TOKEN_START`). `.` and `/` were already valid token *continuation* characters — so `mech/H2/x.yaml` parsed fine — but a path that *starts* with `.` or `/` (`./../mech.yaml`, `/abs/path`) had no valid first character and fell through to a `ParseError` / `invalid string`.

## Fix

Add `.` and `/` to `_IS_TOKEN_START` so a path can begin a word token, matching OpenFOAM (which the reporter confirmed reads these unquoted). This is a monotonic relaxation: numbers are parsed *before* tokens in `_parse_data_entry`, so genuine floats are unaffected — only inputs that previously failed to parse now succeed.

## Verification

Reproduction round-trips cleanly (write → file → read):

```
path ./../mechanisms/H2/CRECK/syngas-creck.yaml;
absPath /abs/x.yaml;
```
```
path    -> "./../mechanisms/H2/CRECK/syngas-creck.yaml"  ✓
absPath -> "/abs/x.yaml"                                  ✓
```

Regression guard — genuine floats still parse as numbers, not strings:

| input | parsed |
|-------|--------|
| `.5`     | `0.5`    |
| `-.5`    | `-0.5`   |
| `1.5e-3` | `0.0015` |
| `5.`     | `5.0`    |

New `tests/test_files/test_parsing/test_issue_761.py` (11 cases) covers path parsing, the `dumps`/`loads` round-trip, the original `FoamFile.add` reporter scenario, and the float-regression guard. Full parsing/serialization suite stays green (104 passed, 15 xfailed); `ruff check`/`ruff format` clean.