### PR TITLE
Fix AttributeError when repr-ing FoamFile key/value/item views

### DIFF
--- a/src/foamlib/_files/files.py
+++ b/src/foamlib/_files/files.py
@@ -105,6 +105,9 @@ class FoamFile(
             self._file = file
             self._include_header = include_header
 
+        def __repr__(self) -> str:
+            return f"{type(self).__qualname__}({list(self)!r})"
+
         @override
         def __iter__(self) -> Iterator[str | None]:
             return self._file._iter(include_header=self._include_header)
@@ -137,6 +140,9 @@ class FoamFile(
         def __init__(self, file: "FoamFile", *, include_header: bool = False) -> None:
             self._file = file
             self._include_header = include_header
+
+        def __repr__(self) -> str:
+            return f"{type(self).__qualname__}({list(self)!r})"
 
         @override
         def __iter__(
@@ -177,6 +183,9 @@ class FoamFile(
         ) -> None:
             self._file = file
             self._include_header = include_header
+
+        def __repr__(self) -> str:
+            return f"{type(self).__qualname__}({list(self)!r})"
 
         @override
         def __iter__(
@@ -244,6 +253,9 @@ class FoamFile(
             def __init__(self, subdict: "FoamFile.SubDict") -> None:
                 self._subdict = subdict
 
+            def __repr__(self) -> str:
+                return f"{type(self).__qualname__}({list(self)!r})"
+
             @override
             def __iter__(self) -> Iterator[str]:
                 return self._subdict._file._iter(keywords=self._subdict._keywords)
@@ -267,6 +279,9 @@ class FoamFile(
         ):
             def __init__(self, subdict: "FoamFile.SubDict") -> None:
                 self._subdict = subdict
+
+            def __repr__(self) -> str:
+                return f"{type(self).__qualname__}({list(self)!r})"
 
             @override
             def __iter__(self) -> Iterator["Data | FoamFile.SubDict | None"]:
@@ -293,6 +308,9 @@ class FoamFile(
         ):
             def __init__(self, subdict: "FoamFile.SubDict") -> None:
                 self._subdict = subdict
+
+            def __repr__(self) -> str:
+                return f"{type(self).__qualname__}({list(self)!r})"
 
             @override
             def __iter__(

--- a/tests/test_files/test_files.py
+++ b/tests/test_files/test_files.py
@@ -307,6 +307,21 @@ def test_popone(tmp_path: Path) -> None:
     popped_dict["nested_key"] = "modified"  # ty: ignore[invalid-assignment]
     # Since the key is already removed, this confirms it's a copy
 
+
+def test_view_repr(tmp_path: Path) -> None:
+    path = tmp_path / "testDict"
+    d = FoamFile(path)
+    d["key"] = "value"
+    d["sub"] = {"nested": 1}
+
+    # The view repr used to raise AttributeError because the base
+    # MappingView.__repr__ expects a _mapping attribute that these views
+    # do not set.
+    assert repr(d.keys()) == "FoamFile.KeysView(['key', 'sub'])"
+    assert "'value'" in repr(d.values())
+    assert "('key', 'value')" in repr(d.items())
+    assert repr(d["sub"].keys()) == "FoamFile.SubDict.KeysView(['nested'])"
+
     # Test popone on SubDict
     d["parent"] = {
         "child1": "value1",


### PR DESCRIPTION
Fixes #781.

`FoamFile.keys()`, `.values()`, and `.items()` (and their `SubDict` equivalents) override `__init__` without setting the `_mapping` attribute that the inherited `MappingView.__repr__` expects, so `repr()` on any of them raised `AttributeError`. This surfaced in interactive sessions where IPython reprs the view. Each view now defines its own `__repr__` that lists its contents.