### PR TITLE
Change Python version to 3.14 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
         slurm: [false]
         include:
           - openfoam-version: 2606
-            python-version: '3.13'
+            python-version: '3.14'
             slurm: true
           - openfoam-version: 13
-            python-version: '3.13'
+            python-version: '3.14'
             slurm: true
           - openfoam-version: 2006
             python-version: '3.10'


### PR DESCRIPTION
Updated Python version from 3.13 to 3.14 for specific OpenFOAM versions.