### PR TITLE
Tolerate OpenFOAM-legal dictionary grammars in the FoamFile parser

### DIFF
--- a/src/foamlib/_files/_normalization.py
+++ b/src/foamlib/_files/_normalization.py
@@ -345,6 +345,12 @@ def _normalized_data(
     match value:
         case DimensionSet():
             return value
+        case (v, {} as d):
+            # Data followed by a subdictionary (primitiveEntry value form)
+            return (
+                _normalized_data(v, keywords=keywords, binary=binary),  # ty: ignore[invalid-argument-type]
+                _normalized_dict(d),  # ty: ignore[invalid-argument-type]
+            )
         case tuple((_, _, *_)):
             return tuple(  # ty: ignore[invalid-return-type]
                 _normalized_data_entry(v, keywords=keywords, binary=binary)  # ty: ignore[invalid-argument-type]

--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -118,6 +118,31 @@ def _skip(
     return pos
 
 
+def _read_delimited(
+    contents: bytes | bytearray,
+    pos: int,
+    *,
+    begin: int,
+    end: int,
+) -> tuple[str, int]:
+    """Read a raw delimited string, mirroring ``ISstream::readDelimited``."""
+    start = pos
+    depth = 0
+    while pos < len(contents):
+        char = contents[pos]
+        if char == begin:
+            depth += 1
+        elif char == end:
+            depth -= 1
+            if depth <= 0:
+                pos += 1
+                break
+        pos += 1
+    if depth != 0:
+        raise ParseError(contents, pos, expected=chr(end))
+    return contents[start:pos].decode("ascii"), pos
+
+
 def _expect(contents: bytes | bytearray, pos: int, expected: bytes | bytearray) -> int:
     length = len(expected)
     if contents[pos : pos + length] != expected:
@@ -146,13 +171,15 @@ def _parse_token(contents: bytes | bytearray, pos: int) -> tuple[str, int]:
         with contextlib.suppress(IndexError):
             while True:
                 if (depth == 0 and _IS_TOKEN_CONTINUATION[char]) or (
-                    depth > 0 and char not in b";(){}[]"
+                    depth > 0 and char not in b"()[]{}"
                 ):
                     end += 1
-                elif char == ord(b"("):
+                elif char == ord(b"(") or (
+                    depth > 0 and char in (ord(b"["), ord(b"{"))
+                ):
                     depth += 1
                     end += 1
-                elif char == ord(b")") and depth > 0:
+                elif depth > 0 and char in (ord(b")"), ord(b"]"), ord(b"}")):
                     depth -= 1
                     end += 1
                 else:
@@ -719,6 +746,69 @@ def _parse_list(
     return ret, pos
 
 
+_UNIT_SYMBOLS: dict[str, tuple[int, int, int, int, int, int, int]] = {
+    # Default SI unit set (OpenFOAM etc/controlDict, DimensionSets/SICoeffs)
+    "kg": (1, 0, 0, 0, 0, 0, 0),
+    "m": (0, 1, 0, 0, 0, 0, 0),
+    "s": (0, 0, 1, 0, 0, 0, 0),
+    "K": (0, 0, 0, 1, 0, 0, 0),
+    "mol": (0, 0, 0, 0, 1, 0, 0),
+    "A": (0, 0, 0, 0, 0, 1, 0),
+    "Cd": (0, 0, 0, 0, 0, 0, 1),
+    "Hz": (0, 0, -1, 0, 0, 0, 0),
+    "N": (1, 1, -2, 0, 0, 0, 0),
+    "Pa": (1, -1, -2, 0, 0, 0, 0),
+    "J": (1, 2, -2, 0, 0, 0, 0),
+    "W": (1, 2, -3, 0, 0, 0, 0),
+    "area": (0, 2, 0, 0, 0, 0, 0),
+    "volume": (0, 3, 0, 0, 0, 0, 0),
+    "density": (1, -3, 0, 0, 0, 0, 0),
+    "acceleration": (0, 1, -2, 0, 0, 0, 0),
+    "kinematicPressure": (0, 2, -2, 0, 0, 0, 0),
+    "cm": (0, 1, 0, 0, 0, 0, 0),
+    "mm": (0, 1, 0, 0, 0, 0, 0),
+    "km": (0, 1, 0, 0, 0, 0, 0),
+}
+
+
+def _parse_unit_symbols(
+    contents: bytes | bytearray,
+    pos: int,
+    first: str,
+) -> tuple[DimensionSet, int]:
+    """Parse a symbolic dimension expression (``dimensionSet::read``)."""
+    exponents = [0] * 7
+    symbol = first
+    while True:
+        base, _, exp = symbol.partition("^")
+        try:
+            dims = _UNIT_SYMBOLS[base]
+        except KeyError:
+            raise FoamFileDecodeError(
+                contents,
+                pos,
+                expected=f"known dimensions name or unit symbol (got {symbol!r})",
+            ) from None
+
+        if exp:
+            try:
+                exponent: int | float = int(exp)
+            except ValueError:
+                exponent = float(exp)
+        else:
+            exponent = 1
+
+        for i, dim in enumerate(dims):
+            exponents[i] += dim * exponent
+
+        pos = _skip(contents, pos)
+        if contents[pos : pos + 1] == b"]":
+            break
+        symbol, pos = _parse_token(contents, pos)
+
+    return DimensionSet(*exponents), pos
+
+
 def _parse_dimensions(
     contents: bytes | bytearray, pos: int
 ) -> tuple[DimensionSet, int]:
@@ -736,12 +826,8 @@ def _parse_dimensions(
         try:
             ret = _NAMED_DIMENSIONS[name]
             assert isinstance(ret, DimensionSet)
-        except KeyError as e:
-            raise FoamFileDecodeError(
-                contents,
-                pos,
-                expected=f"known dimensions name (got {name!r})",
-            ) from e
+        except KeyError:
+            ret, pos = _parse_unit_symbols(contents, pos, name)
     else:
         dims = [first_dim]
         for _ in range(6):
@@ -803,11 +889,10 @@ def _parse_keyword_entry(
     try:
         value, pos = _parse_dictionary(contents, pos)
     except ParseError:
-        value, pos = _parse_data(contents, pos)
-        pos = _skip(contents, pos)
+        value, pos = _parse_entry_value(contents, pos)
         pos = _expect(contents, pos, b";")
 
-    return (keyword, value), pos
+    return (keyword, value), pos  # ty: ignore[invalid-return-type]
 
 
 def _parse_dictionary(contents: bytes | bytearray, pos: int) -> tuple[Dict, int]:
@@ -819,6 +904,9 @@ def _parse_dictionary(contents: bytes | bytearray, pos: int) -> tuple[Dict, int]
         if contents[pos : pos + 1] == b"}":
             pos += 1
             break
+        if contents[pos : pos + 1] == b";":
+            pos = _skip(contents, pos + 1)
+            continue
 
         keyword, pos = _parse_token(contents, pos)
 
@@ -841,8 +929,7 @@ def _parse_dictionary(contents: bytes | bytearray, pos: int) -> tuple[Dict, int]
         try:
             value, pos = _parse_dictionary(contents, pos)
         except ParseError:
-            value, pos = _parse_data(contents, pos)
-            pos = _skip(contents, pos)
+            value, pos = _parse_entry_value(contents, pos)
             pos = _expect(contents, pos, b";")
 
         ret[keyword] = value
@@ -892,6 +979,9 @@ def _parse_subdictionary(contents: bytes | bytearray, pos: int) -> tuple[SubDict
         if contents[pos : pos + 1] == b"}":
             pos += 1
             break
+        if contents[pos : pos + 1] == b";":
+            pos = _skip(contents, pos + 1)
+            continue
 
         keyword, pos = _parse_token(contents, pos)
 
@@ -899,20 +989,18 @@ def _parse_subdictionary(contents: bytes | bytearray, pos: int) -> tuple[SubDict
 
         if keyword.startswith("#"):
             value, pos = _parse_data_entry(contents, pos)
-            pos = _skip(contents, pos, newline_ok=False)
-            if pos < len(contents):
-                pos = _expect(contents, pos, b"\n")
+            value, pos = _parse_directive_value(contents, keyword, value, pos)
         else:
             try:
                 value, pos = _parse_subdictionary(contents, pos)
             except ParseError:
-                try:
-                    value, pos = _parse_data(contents, pos)
-                except ParseError:
-                    value = None
+                value, pos = _parse_entry_value(contents, pos)
+                if keyword.startswith("$") and value is None:
+                    # Bare '$'-reference entry (whole-entry substitution)
+                    if contents[pos : pos + 1] == b";":
+                        pos += 1
                 else:
-                    pos = _skip(contents, pos)
-                pos = _expect(contents, pos, b";")
+                    pos = _expect(contents, pos, b";")
 
         if keyword in ret and not keyword.startswith("#"):
             warn(
@@ -925,6 +1013,47 @@ def _parse_subdictionary(contents: bytes | bytearray, pos: int) -> tuple[SubDict
             ret = add_to_mapping(ret, keyword, value)
 
     return ret, pos
+
+
+def _parse_entry_value(
+    contents: bytes | bytearray, pos: int
+) -> tuple[Data | None, int]:
+    """Parse a keyword-entry value, allowing a trailing subdictionary.
+
+    OpenFOAM's ``primitiveEntry::read`` reads tokens until a ``;`` at block
+    depth zero, so ``key word(s) { ... };`` is a single entry whose value is
+    the data followed by the subdictionary.
+    """
+    try:
+        value, pos = _parse_data(contents, pos)
+    except ParseError:
+        return None, pos
+    pos = _skip(contents, pos)
+    if contents[pos : pos + 1] == b"{":
+        subdict, pos = _parse_subdictionary(contents, pos)
+        value = (value, subdict)
+    return value, pos
+
+
+def _parse_directive_value(
+    contents: bytes | bytearray,
+    keyword: str,
+    value: Data,
+    pos: int,
+) -> tuple[Data, int]:
+    """Parse a directive value, allowing ``#includeFunc`` arguments on the next line."""
+    if keyword == "#includeFunc" and isinstance(value, str) and "(" not in value:
+        # Optional arguments may start on the next line
+        # (functionEntry::readFuncNameArgs)
+        peek = _skip(contents, pos, newline_ok=True)
+        if contents[peek : peek + 1] == b"(":
+            args, pos = _read_delimited(contents, peek, begin=ord("("), end=ord(")"))
+            value = value + " ".join(args.split())
+            return value, pos
+    pos = _skip(contents, pos, newline_ok=False)
+    if pos < len(contents):
+        pos = _expect(contents, pos, b"\n")
+    return value, pos
 
 
 def _parse_standalone_data_entry(
@@ -1000,7 +1129,18 @@ def _parse_standalone_data(
 def _parse_file(contents: bytes | bytearray, pos: int = 0) -> tuple[FileDict, int]:
     ret: FileDict = {}
 
-    while (pos := _skip(contents, pos)) < len(contents):
+    while True:
+        pos = _skip(contents, pos)
+        if pos >= len(contents):
+            break
+        if contents[pos : pos + 1] == b";":
+            # Discard spurious statement terminators (entry::getKeyword)
+            pos += 1
+            continue
+        if contents[pos : pos + 1] == b"}":
+            # A stray top-level block close ends the read (dictionary::read)
+            return ret, len(contents)
+
         try:
             keyword, new_pos = _parse_token(contents, pos)
 
@@ -1008,20 +1148,20 @@ def _parse_file(contents: bytes | bytearray, pos: int = 0) -> tuple[FileDict, in
 
             if keyword.startswith("#"):
                 value, new_pos = _parse_data_entry(contents, new_pos)
-                new_pos = _skip(contents, new_pos, newline_ok=False)
-                if new_pos < len(contents):
-                    new_pos = _expect(contents, new_pos, b"\n")
+                value, new_pos = _parse_directive_value(
+                    contents, keyword, value, new_pos
+                )
             else:
                 try:
                     value, new_pos = _parse_subdictionary(contents, new_pos)
                 except ParseError:
-                    try:
-                        value, new_pos = _parse_data(contents, new_pos)
-                    except ParseError:
-                        value = None
+                    value, new_pos = _parse_entry_value(contents, new_pos)
+                    if keyword.startswith("$") and value is None:
+                        # Bare '$'-reference entry (whole-entry substitution)
+                        if contents[new_pos : new_pos + 1] == b";":
+                            new_pos += 1
                     else:
-                        new_pos = _skip(contents, new_pos)
-                    new_pos = _expect(contents, new_pos, b";")
+                        new_pos = _expect(contents, new_pos, b";")
 
             if keyword in ret and not keyword.startswith("#"):
                 warn(
@@ -1096,10 +1236,20 @@ def _parse_file_located(
 ) -> tuple[MultiDict[tuple[str, ...], ParsedEntry], int]:
     ret: MultiDict[tuple[str, ...], ParsedEntry] = MultiDict()
 
-    while (pos := _skip(contents, pos)) < len(contents):
+    while True:
+        pos = _skip(contents, pos)
+        if pos >= len(contents):
+            break
         # Check if we've hit a closing brace (end of subdictionary)
         if _keywords and contents[pos : pos + 1] == b"}":
             return ret, pos
+        if contents[pos : pos + 1] == b";":
+            # Discard spurious statement terminators (entry::getKeyword)
+            pos = _skip(contents, pos + 1)
+            continue
+        if contents[pos : pos + 1] == b"}":
+            # A stray top-level block close ends the read (dictionary::read)
+            return ret, len(contents)
 
         entry_start = pos
         try:
@@ -1108,10 +1258,9 @@ def _parse_file_located(
 
             if keyword.startswith("#"):
                 value, new_pos = _parse_data_entry(contents, new_pos)
-                new_pos = _skip(contents, new_pos, newline_ok=False)
-                # Expect newline or end for directives
-                if new_pos < len(contents):
-                    new_pos = _expect(contents, new_pos, b"\n")
+                value, new_pos = _parse_directive_value(
+                    contents, keyword, value, new_pos
+                )
                 ret.add((*_keywords, keyword), ParsedEntry(value, entry_start, new_pos))
             # Check if this is a subdictionary
             elif contents[new_pos : new_pos + 1] == b"{":
@@ -1141,13 +1290,13 @@ def _parse_file_located(
                 ret[(*_keywords, keyword)] = ParsedEntry(..., entry_start, new_pos)
                 ret.extend(subdict_result)
             else:
-                try:
-                    value, new_pos = _parse_data(contents, new_pos)
-                except ParseError:
-                    value = None
+                value, new_pos = _parse_entry_value(contents, new_pos)
+                if keyword.startswith("$") and value is None:
+                    # Bare '$'-reference entry (whole-entry substitution)
+                    if contents[new_pos : new_pos + 1] == b";":
+                        new_pos += 1
                 else:
-                    new_pos = _skip(contents, new_pos)
-                new_pos = _expect(contents, new_pos, b";")
+                    new_pos = _expect(contents, new_pos, b";")
 
                 if not keyword.startswith("#"):
                     if (*_keywords, keyword) in ret:

--- a/src/foamlib/_files/_serialization.py
+++ b/src/foamlib/_files/_serialization.py
@@ -147,7 +147,11 @@ def dumps(
                 ret += val
                 if isinstance(k, str) and k[0] == "#":
                     ret += b"\n"
-                elif k is not None and not isinstance(v, Mapping):
+                elif (
+                    k is not None
+                    and not isinstance(v, Mapping)
+                    and not (isinstance(k, str) and k.startswith("$") and v is None)
+                ):
                     ret += b";"
                 return ret
 

--- a/tests/test_files/test_parsing/test_basic.py
+++ b/tests/test_files/test_parsing/test_basic.py
@@ -215,7 +215,7 @@ def test_parse_invalid_content() -> None:
         ParsedFile(b"key value; unclosed {")
 
     with pytest.raises(FoamFileDecodeError):
-        ParsedFile(b"key { value; } extra }")
+        ParsedFile(b"key { value; } {")
 
     with pytest.raises(FoamFileDecodeError):
         ParsedFile(b"{ orphaned brace")

--- a/tests/test_files/test_parsing/test_intermediate.py
+++ b/tests/test_files/test_parsing/test_intermediate.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from foamlib import Dimensioned, DimensionSet, FoamFileDecodeError
+from foamlib import Dimensioned, DimensionSet
 from foamlib._files._parsing import ParsedFile
 
 
@@ -558,18 +558,27 @@ def test_list_numbered() -> None:
 
 
 def test_list_numbered_u() -> None:
-    with pytest.raises(FoamFileDecodeError):
-        ParsedFile(b"""
-            70
-            (
-                (5.74803 0 0)
-                (5.74803 0 0)
-                (11.3009 0 0)
-                (13.4518 0 0)
-                (13.4518 0 0)
-                (14.0472 0 0)
-            );
-        """)
+    # A standalone counted list that does not match its count falls through to
+    # general standalone data, and the trailing ';' is discarded like any
+    # spurious statement terminator (entry::getKeyword).
+    parsed = ParsedFile(
+        b"""
+        70
+        (
+            (5.74803 0 0)
+            (5.74803 0 0)
+            (11.3009 0 0)
+            (13.4518 0 0)
+            (13.4518 0 0)
+            (14.0472 0 0)
+        );
+        """
+    )
+    data = parsed[()]
+    assert isinstance(data, tuple)
+    assert data[0] == 70
+    assert isinstance(data[1], list)
+    assert len(data[1]) == 6
 
 
 def test_colon_double_name() -> None:

--- a/tests/test_files/test_parsing/test_openfoam_grammar_tolerance.py
+++ b/tests/test_files/test_parsing/test_openfoam_grammar_tolerance.py
@@ -1,0 +1,163 @@
+"""OpenFOAM-grammar tolerance parity tests.
+
+foamlib's FoamFile parser was stricter than OpenFOAM's token-based parser at
+statement boundaries, rejecting a family of legal dictionary forms (100 of the
+4234 dictionary files shipped with OpenFOAM-11). Each case mirrors the
+OpenFOAM-11 parser source (entryIO.C, primitiveEntryIO.C, functionEntry.C,
+dictionaryIO.C, dimensionSetIO.C) and round-trips through the data model.
+"""
+
+import pytest
+
+from foamlib import Dimensioned, DimensionSet, FoamFile, FoamFileDecodeError
+from foamlib._files._parsing import ParsedFile, parse
+from foamlib.typing import FileDict
+
+
+def _file_dict(contents: bytes) -> FileDict:
+    return parse(contents, target=FileDict)  # ty: ignore[invalid-argument-type]
+
+
+def test_spurious_semicolon_after_subdictionary() -> None:
+    # entry::getKeyword: "Read the next valid token discarding spurious ';'s"
+    assert _file_dict(b"a {x 1;}; b 2;") == {"a": {"x": 1}, "b": 2}
+    assert _file_dict(b"outer {a {x 1;}; b 2;}") == {"outer": {"a": {"x": 1}, "b": 2}}
+    parsed = ParsedFile(b"a {x 1;}; b 2;")
+    assert parsed[("a", "x")] == 1
+    assert parsed[("b",)] == 2
+
+
+def test_spurious_semicolon_after_standalone_list() -> None:
+    # Same getKeyword discard; parcelInjectionProperties files end with ");"
+    parsed = ParsedFile(b"(\n (0 1 2) (3 4 5) 1.0 2.0 (1)\n);")
+    assert parsed[()] == [[0, 1, 2], [3, 4, 5], 1.0, 2.0, [1]]
+
+
+def test_value_then_subdictionary() -> None:
+    # primitiveEntry::read reads tokens until a ';' at blockCount 0, so a
+    # trailing subdictionary is part of the value (fvSchemes ddtSchemes/
+    # divSchemes).
+    assert _file_dict(
+        b"ddtSchemes {default CrankNicolson ocCoeff {type scale; value 0.9;};}"
+    ) == {
+        "ddtSchemes": {
+            "default": (
+                ("CrankNicolson", "ocCoeff"),
+                {"type": "scale", "value": 0.9},
+            )
+        }
+    }
+    assert _file_dict(b"key CrankNicolson {x 1;};") == {
+        "key": ("CrankNicolson", {"x": 1})
+    }
+    assert _file_dict(
+        b"div(phi,Yi_h) Gauss multivariateSelection {O2 limitedLinear01 1;};"
+    ) == {
+        "div(phi,Yi_h)": (
+            ("Gauss", "multivariateSelection"),
+            {"O2": ("limitedLinear01", 1)},
+        )
+    }
+
+
+def test_include_func_args_on_next_line() -> None:
+    # functionEntry::readFuncNameArgs reads the next token in case the
+    # optional arguments start on the next line; name and args are stored as
+    # one value.
+    parsed = ParsedFile(
+        b"functions {\n#includeFunc streamlinesSphere\n"
+        b"( name=streamlines, fields=(U) )\n}"
+    )
+    assert parsed[("functions", "#includeFunc")] == (
+        "streamlinesSphere( name=streamlines, fields=(U) )"
+    )
+    # Same-line arguments are unchanged.
+    assert _file_dict(b"functions {#includeFunc fieldAverage(U, p)\n}") == {
+        "functions": {"#includeFunc": "fieldAverage(U, p)"}
+    }
+    # Arguments may contain dimension sets and nested lists.
+    assert _file_dict(
+        b"functions {#includeFunc uniform( dimensions = [0 0 0 0 0 0 0], value = 0.5 )\n}"
+    ) == {
+        "functions": {
+            "#includeFunc": ("uniform( dimensions = [0 0 0 0 0 0 0], value = 0.5 )")
+        }
+    }
+    # Other directives still require the value on one line.
+    assert _file_dict(b'#include "file"\n') == {"#include": '"file"'}
+
+
+def test_stray_top_level_brace() -> None:
+    # dictionary::read loops until entry::New returns false; an END_BLOCK
+    # token ends the read silently (wingMotion/.../system/controlDict).
+    assert _file_dict(b"a 1;\n}") == {"a": 1}
+    assert _file_dict(b"a 1;\n}\n// footer\n") == {"a": 1}
+    parsed = ParsedFile(b"a 1;\n}\n// footer\n")
+    assert parsed[("a",)] == 1
+
+
+@pytest.mark.parametrize(
+    ("contents", "expected"),
+    [
+        (b"[m^2 s^-3]", DimensionSet(length=2, time=-3)),
+        (b"[m s^-1]", DimensionSet(length=1, time=-1)),
+        (b"[kg m s^-2]", DimensionSet(mass=1, length=1, time=-2)),
+        (b"[Pa]", DimensionSet(mass=1, length=-1, time=-2)),
+        (b"[N m^-2]", DimensionSet(mass=1, length=-1, time=-2)),
+        (b"[cm]", DimensionSet(length=1)),
+        (b"[m^0.5]", DimensionSet(length=0.5)),
+    ],
+)
+def test_symbolic_dimensions(contents: bytes, expected: DimensionSet) -> None:
+    # dimensionSet::read parses consecutive unit-symbol words with powers
+    # from the default SI unit set.
+    assert ParsedFile(b"dimensions " + contents + b";")[("dimensions",)] == expected
+
+
+def test_symbolic_dimensions_unknown_unit() -> None:
+    with pytest.raises(FoamFileDecodeError, match="unit symbol"):
+        ParsedFile(b"dimensions [foo];")
+    # '/' expressions belong to the dimensionedScalar grammar, not dimensionSet.
+    with pytest.raises(FoamFileDecodeError):
+        ParsedFile(b"dimensions [kg/m^3];")
+
+
+def test_named_dimensions_still_accepted() -> None:
+    assert ParsedFile(b"dimensions [velocity];")[("dimensions",)] == DimensionSet(
+        length=1, time=-1
+    )
+
+
+def test_dimensioned_value_with_symbolic_units() -> None:
+    parsed = ParsedFile(b"p [Pa] 1e5;")
+
+    value = parsed[("p",)]
+    assert isinstance(value, Dimensioned)
+    assert value.dimensions == DimensionSet(mass=1, length=-1, time=-2)
+    assert value.value == 100000.0
+
+
+def test_bare_dollar_reference_entry() -> None:
+    # entry::New substitution entries ($name) replace the whole entry and
+    # take no statement terminator.
+    assert _file_dict(b"TiO2_s {$TiO2}") == {"TiO2_s": {"$TiO2": None}}
+    assert _file_dict(b"TiO2_s {$TiO2;}") == {"TiO2_s": {"$TiO2": None}}
+    parsed = ParsedFile(b"TiO2 {rho 2000;} TiO2_s {$TiO2}")
+    assert parsed[("TiO2_s", "$TiO2")] is None
+    assert FoamFile.dumps(_file_dict(b"TiO2_s {$TiO2}"), ensure_header=False) == (
+        b"TiO2_s {$TiO2}"
+    )
+
+
+def test_grammar_tolerance_round_trip() -> None:
+    cases = [
+        b"a {x 1;}; b 2;",
+        b"(\n (0 1 2) (3 4 5) 1.0 2.0 (1)\n);",
+        b"ddtSchemes {default CrankNicolson ocCoeff {type scale; value 0.9;};}",
+        b"functions {#includeFunc fieldAverage(U, p)\n}",
+        b"dimensions [m^2 s^-3];",
+        b"TiO2_s {$TiO2}",
+    ]
+    for contents in cases:
+        dumped = FoamFile.dumps(_file_dict(contents), ensure_header=False)
+        assert _file_dict(dumped) == _file_dict(contents)


### PR DESCRIPTION
foamlib's FoamFile parser rejects a family of OpenFOAM-legal dictionary grammars: 100 of the 4234
dictionary files shipped with OpenFOAM-11 fail to load with FoamFileDecodeError. The parser now
mirrors OpenFOAM's tokenizer at statement boundaries: spurious `;` after `}`/`)` is discarded
(entry::getKeyword), a value ending in a `{ ... }` subdictionary is one entry (primitiveEntry::read),
`#includeFunc` arguments may start on the next line (functionEntry::readFuncNameArgs), a stray
top-level `}` ends the read (dictionary::read), symbolic dimension sets like `[m^2 s^-3]` parse via
the SI unit set (dimensionSet::read), and bare `$name` substitution entries are accepted. All seven
forms round-trip through the data model; 4230 of the 4234 tutorial dictionaries now load on both
parse paths (the only remaining failure is one malformed corpus file that OpenFOAM cannot read
either).

Repro: `FoamFile.loads` on any of the 100 files, e.g. tutorials/incompressibleFluid/TJunctionFan/0/k.orig.
