### PR TITLE
Carry the unit scale multiplier through symbolic dimension sets

### DIFF
--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -1,6 +1,8 @@
 import contextlib
 import dataclasses
+import math
 import re
+import sys
 from types import EllipsisType
 from typing import Generic, Literal, TypeVar, TypeVarTuple, assert_never, overload
 from warnings import warn
@@ -770,64 +772,203 @@ _UNIT_SYMBOLS: dict[str, tuple[int, int, int, int, int, int, int]] = {
     "km": (0, 1, 0, 0, 0, 0, 0),
 }
 
+_UNIT_MULTIPLIERS: dict[str, float] = {
+    # Scaled units: the only SICoeffs entries whose multiplier is not 1
+    "cm": 1e-2,
+    "mm": 1e-3,
+    "km": 1e3,
+}
+
+# dimensionSet::smallExponent
+_SMALL_EXPONENT = math.sqrt(sys.float_info.epsilon)
+
+# Characters rejected by symbols::tokeniser::valid(), i.e. that end a unit symbol
+_SYMBOL_SEPARATORS = "\"'/;:{}()[]^* \t\n\r\f\v"
+_SYMBOL_OPERATORS = "*/^()"
+
+_MULTIPLY_PRIORITY = 2
+_POWER_PRIORITY = 3
+
+_SymbolToken = tuple[str, str | float]
+
+
+class _SymbolTokenizer:
+    """Token stream for a symbolic dimension set (``symbols::tokeniser``)."""
+
+    def __init__(self, contents: bytes | bytearray, pos: int, first: str) -> None:
+        self.contents = contents
+        self.pos = pos
+        self._pending: list[_SymbolToken] = []
+        self._split(first)
+
+    def _split(self, word: str) -> None:
+        """Break a word into unit symbols, numbers and operators."""
+        start = 0
+        for i, char in enumerate(word):
+            if char in _SYMBOL_SEPARATORS:
+                if i > start:
+                    self._push(word[start:i])
+                if not char.isspace():
+                    self._pending.append(("punctuation", char))
+                start = i + 1
+        if start < len(word):
+            self._push(word[start:])
+
+    def _push(self, word: str) -> None:
+        if word[0].isdigit() or word[0] == "-":
+            try:
+                number: int | float = int(word)
+            except ValueError:
+                try:
+                    number = float(word)
+                except ValueError:
+                    raise FoamFileDecodeError(
+                        self.contents, self.pos, expected=f"a number (got {word!r})"
+                    ) from None
+            self._pending.append(("number", number))
+        else:
+            self._pending.append(("symbol", word))
+
+    def next(self) -> _SymbolToken | None:
+        """Return the next token, or None at the end of the dimension set."""
+        while not self._pending:
+            self.pos = _skip(self.contents, self.pos)
+            char = self.contents[self.pos : self.pos + 1].decode("ascii", "replace")
+            if char in ("", "]"):
+                return None
+            if char in _SYMBOL_OPERATORS:
+                self.pos += 1
+                return ("punctuation", char)
+            word, self.pos = _parse_token(self.contents, self.pos)
+            self._split(word)
+        return self._pending.pop(0)
+
+    def put_back(self, token: _SymbolToken) -> None:
+        self._pending.insert(0, token)
+
 
 def _parse_unit_symbols(
-    contents: bytes | bytearray,
-    pos: int,
-    first: str,
-) -> tuple[DimensionSet, int]:
-    """Parse a symbolic dimension expression (``dimensionSet::read``)."""
-    exponents = [0] * 7
-    symbol = first
-    while True:
-        base, _, exp = symbol.partition("^")
-        try:
-            dims = _UNIT_SYMBOLS[base]
-        except KeyError:
-            raise FoamFileDecodeError(
-                contents,
-                pos,
-                expected=f"known dimensions name or unit symbol (got {symbol!r})",
-            ) from None
+    tokenizer: _SymbolTokenizer, last_priority: int = 0
+) -> tuple[list[float], float]:
+    """Evaluate a symbolic dimension expression (``symbols::parseNoBegin``).
 
-        if exp:
+    Returns the dimension exponents and the scale multiplier of the units used.
+    """
+    exponents: list[float] = [0] * 7
+    multiplier = 1.0
+    have_symbol = False
+
+    token = tokenizer.next()
+    while token is not None:
+        kind, value = token
+
+        if kind == "symbol":
+            assert isinstance(value, str)
             try:
-                exponent: int | float = int(exp)
-            except ValueError:
-                exponent = float(exp)
-        else:
-            exponent = 1
+                dims = _UNIT_SYMBOLS[value]
+            except KeyError:
+                raise FoamFileDecodeError(
+                    tokenizer.contents,
+                    tokenizer.pos,
+                    expected=f"known dimensions name or unit symbol (got {value!r})",
+                ) from None
+            exponents = [e + d for e, d in zip(exponents, dims)]
+            multiplier *= _UNIT_MULTIPLIERS.get(value, 1.0)
+            have_symbol = True
 
-        for i, dim in enumerate(dims):
-            exponents[i] += dim * exponent
+        elif value == "(":
+            sub_exponents, sub_multiplier = _parse_unit_symbols(tokenizer)
+            if tokenizer.next() != ("punctuation", ")"):
+                raise FoamFileDecodeError(
+                    tokenizer.contents, tokenizer.pos, expected=")"
+                )
+            exponents = [e + s for e, s in zip(exponents, sub_exponents)]
+            multiplier *= sub_multiplier
+            have_symbol = True
 
-        pos = _skip(contents, pos)
-        if contents[pos : pos + 1] == b"]":
+        elif value == ")":
+            tokenizer.put_back(token)
             break
-        symbol, pos = _parse_token(contents, pos)
 
-    return DimensionSet(*exponents), pos
+        elif value in ("*", "/"):
+            if _MULTIPLY_PRIORITY <= last_priority:
+                tokenizer.put_back(token)
+                break
+            sub_exponents, sub_multiplier = _parse_unit_symbols(
+                tokenizer, _MULTIPLY_PRIORITY
+            )
+            sign = 1 if value == "*" else -1
+            exponents = [e + sign * s for e, s in zip(exponents, sub_exponents)]
+            multiplier *= sub_multiplier**sign
+            have_symbol = False
+
+        elif value == "^":
+            if _POWER_PRIORITY <= last_priority:
+                tokenizer.put_back(token)
+                break
+            exponent = tokenizer.next()
+            if exponent is None or exponent[0] != "number":
+                raise FoamFileDecodeError(
+                    tokenizer.contents, tokenizer.pos, expected="an exponent after '^'"
+                )
+            power = exponent[1]
+            assert not isinstance(power, str)
+            exponents = [e * power for e in exponents]
+            try:
+                multiplier **= power
+            except OverflowError:
+                raise FoamFileDecodeError(
+                    tokenizer.contents, tokenizer.pos, expected="a finite unit scale"
+                ) from None
+            have_symbol = True
+
+        else:
+            raise FoamFileDecodeError(
+                tokenizer.contents,
+                tokenizer.pos,
+                expected=f"a unit symbol or operator (got {value!r})",
+            )
+
+        token = tokenizer.next()
+        if have_symbol and token is not None and token[0] != "punctuation":
+            # Consecutive symbols are multiplied
+            tokenizer.put_back(token)
+            token = ("punctuation", "*")
+
+    return exponents, multiplier
 
 
-def _parse_dimensions(
+def _parse_dimensions_and_multiplier(
     contents: bytes | bytearray, pos: int
-) -> tuple[DimensionSet, int]:
+) -> tuple[DimensionSet, float, int]:
     pos = _expect(contents, pos, b"[")
     pos = _skip(contents, pos)
 
+    multiplier = 1.0
+
     if contents[pos : pos + 1] == b"]":
         pos += 1
-        return DimensionSet(), pos
+        return DimensionSet(), multiplier, pos
 
     try:
         first_dim, pos = _parse_number(contents, pos)
     except ParseError:
-        name, pos = _parse_token(contents, pos)
+        try:
+            name, pos = _parse_token(contents, pos)
+        except ParseError:
+            if contents[pos : pos + 1] != b"(":
+                raise
+            name = ""
         try:
             ret = _NAMED_DIMENSIONS[name]
             assert isinstance(ret, DimensionSet)
         except KeyError:
-            ret, pos = _parse_unit_symbols(contents, pos, name)
+            tokenizer = _SymbolTokenizer(contents, pos, name)
+            exponents, multiplier = _parse_unit_symbols(tokenizer)
+            if tokenizer.next() is not None:
+                raise FoamFileDecodeError(contents, tokenizer.pos, expected="]")
+            ret = DimensionSet(*exponents)
+            pos = tokenizer.pos
     else:
         dims = [first_dim]
         for _ in range(6):
@@ -851,6 +992,24 @@ def _parse_dimensions(
     pos = _skip(contents, pos)
     pos = _expect(contents, pos, b"]")
 
+    return ret, multiplier, pos
+
+
+def _parse_dimensions(
+    contents: bytes | bytearray, pos: int
+) -> tuple[DimensionSet, int]:
+    ret, multiplier, pos = _parse_dimensions_and_multiplier(contents, pos)
+
+    if abs(multiplier - 1.0) > _SMALL_EXPONENT:
+        # operator>>(Istream&, dimensionSet&): scaled units are only meaningful
+        # where the multiplier can be applied to a value
+        raise FoamFileDecodeError(
+            contents,
+            pos,
+            expected="unscaled units (scaled units are only allowed in a"
+            " dimensioned value)",
+        )
+
     return ret, pos
 
 
@@ -863,9 +1022,13 @@ def _parse_dimensioned(
         name = None
     else:
         pos = _skip(contents, pos)
-    dimensions, pos = _parse_dimensions(contents, pos)
+    dimensions, multiplier, pos = _parse_dimensions_and_multiplier(contents, pos)
     pos = _skip(contents, pos)
     value, pos = _parse_tensor(contents, pos)
+
+    if abs(multiplier - 1.0) > _SMALL_EXPONENT:
+        # dimensioned<Type>::initialise: the value is given in the units read
+        value = value * multiplier
 
     return Dimensioned(value, dimensions, name), pos
 

--- a/tests/test_files/test_parsing/test_openfoam_grammar_tolerance.py
+++ b/tests/test_files/test_parsing/test_openfoam_grammar_tolerance.py
@@ -104,8 +104,17 @@ def test_stray_top_level_brace() -> None:
         (b"[kg m s^-2]", DimensionSet(mass=1, length=1, time=-2)),
         (b"[Pa]", DimensionSet(mass=1, length=-1, time=-2)),
         (b"[N m^-2]", DimensionSet(mass=1, length=-1, time=-2)),
-        (b"[cm]", DimensionSet(length=1)),
         (b"[m^0.5]", DimensionSet(length=0.5)),
+        # Explicit operators: '*' and '/' bind at priority 2, '^' at 3, and
+        # parentheses group.
+        (b"[kg*m^-3]", DimensionSet(mass=1, length=-3)),
+        (b"[kg/m^3]", DimensionSet(mass=1, length=-3)),
+        (b"[N/m^2]", DimensionSet(mass=1, length=-1, time=-2)),
+        (b"[m^2/s]", DimensionSet(length=2, time=-1)),
+        (b"[m/s/s]", DimensionSet(length=1, time=-2)),
+        (b"[J/(kg K)]", DimensionSet(length=2, time=-2, temperature=-1)),
+        (b"[kg/(m s^2)]", DimensionSet(mass=1, length=-1, time=-2)),
+        (b"[(kg m)/s^2]", DimensionSet(mass=1, length=1, time=-2)),
     ],
 )
 def test_symbolic_dimensions(contents: bytes, expected: DimensionSet) -> None:
@@ -114,18 +123,80 @@ def test_symbolic_dimensions(contents: bytes, expected: DimensionSet) -> None:
     assert ParsedFile(b"dimensions " + contents + b";")[("dimensions",)] == expected
 
 
-def test_symbolic_dimensions_unknown_unit() -> None:
-    with pytest.raises(FoamFileDecodeError, match="unit symbol"):
-        ParsedFile(b"dimensions [foo];")
-    # '/' expressions belong to the dimensionedScalar grammar, not dimensionSet.
+@pytest.mark.parametrize(
+    "contents",
+    [
+        b"[foo]",
+        b"[m^]",
+        b"[m^x]",
+        b"[m^-]",
+        b"[m^++]",
+        b"[m)]",
+        b"[km^400]",
+    ],
+)
+def test_symbolic_dimensions_invalid(contents: bytes) -> None:
+    # FoamFileDecodeError is the parser's only error type; a non-numeric power
+    # used to escape as a bare ValueError from float().
     with pytest.raises(FoamFileDecodeError):
-        ParsedFile(b"dimensions [kg/m^3];")
+        ParsedFile(b"dimensions " + contents + b";")
 
 
 def test_named_dimensions_still_accepted() -> None:
     assert ParsedFile(b"dimensions [velocity];")[("dimensions",)] == DimensionSet(
         length=1, time=-1
     )
+
+
+# etc/controlDict DimensionSets/SICoeffs: the only unit symbols whose scale
+# multiplier is not 1.
+SCALED_UNITS = {"cm": 1e-2, "mm": 1e-3, "km": 1e3}
+
+
+@pytest.mark.parametrize("symbol", sorted(SCALED_UNITS))
+def test_scaled_units_rejected_in_dimension_set(symbol: str) -> None:
+    # operator>>(Istream&, dimensionSet&): "Cannot use scaled units in
+    # dimensionSet". Accepting them silently discarded the scale.
+    for contents in (
+        f"[{symbol}]".encode(),
+        f"[{symbol} s^-1]".encode(),
+        f"[{symbol}^2]".encode(),
+    ):
+        with pytest.raises(FoamFileDecodeError, match="unscaled units"):
+            ParsedFile(b"dimensions " + contents + b";")
+
+
+@pytest.mark.parametrize(
+    ("units", "expected"),
+    [
+        (b"m", 5.0),
+        (b"Pa", 5.0),
+        (b"mm km", 5.0),  # 1e-3 * 1e3 == 1
+        (b"cm", 5e-2),
+        (b"mm", 5e-3),
+        (b"km", 5e3),
+        (b"cm^2", 5e-4),
+        (b"cm^-1", 5e2),
+        (b"km^3", 5e9),
+        (b"cm s^-1", 5e-2),
+        (b"km/s", 5e3),
+        (b"m/mm", 5e3),
+        (b"kg/cm^3", 5e6),
+    ],
+)
+def test_dimensioned_value_scaled_by_units(units: bytes, expected: float) -> None:
+    # dimensioned<Type>::initialise reads the dimension set and its multiplier,
+    # then applies the multiplier to the value: "p [cm] 5" is 5 cm, i.e. 0.05 m.
+    value = ParsedFile(b"p p [" + units + b"] 5;")[("p",)]
+    assert isinstance(value, Dimensioned)
+    assert value.value == pytest.approx(expected, rel=1e-12, abs=0.0)
+
+
+def test_dimensioned_tensor_value_scaled_by_units() -> None:
+    value = ParsedFile(b"U U [cm s^-1] (1 2 3);")[("U",)]
+    assert isinstance(value, Dimensioned)
+    assert value.dimensions == DimensionSet(length=1, time=-1)
+    assert value.value == pytest.approx([1e-2, 2e-2, 3e-2], rel=1e-12, abs=0.0)
 
 
 def test_dimensioned_value_with_symbolic_units() -> None:


### PR DESCRIPTION
Follow-up to #829, which added the symbolic unit-set path (`dimensions [kg m s^-2];`).
That path accumulates dimension *exponents* only. OpenFOAM's parser carries a **scale
multiplier** next to the exponents, and its callers use it — so dropping it silently
changes values:

```python
>>> ParsedFile(b"p p [cm] 5;")[("p",)].value
5.0                        # OpenFOAM: 5 cm, i.e. 0.05 m
>>> ParsedFile(b"dimensions [cm];")[("dimensions",)]
DimensionSet(length=1)     # OpenFOAM: "Cannot use scaled units in dimensionSet"
>>> ParsedFile(b"dimensions [kg/m^3];")
FoamFileDecodeError: ... Expected: known dimensions name or unit symbol (got 'kg/m^3')
>>> ParsedFile(b"dimensions [m^2/s];")
ValueError: could not convert string to float: '2/s'
```

The last one escapes as a bare `ValueError` rather than a `FoamFileDecodeError`, with no
position information: `_parse_unit_symbols` split `symbol^exponent` lexically, so anything
after `^` up to the next space was fed straight to `float()`.

### Root cause

`_parse_unit_symbols` implemented a subset of the OpenFOAM grammar: space-separated
`symbol[^exponent]` atoms, dimensions only. The real parser is a small recursive-descent
evaluator over a symbol table, and it evaluates dimensions *and* a multiplier in lockstep.

### Oracle

OpenFOAM-11 `src/OpenFOAM/dimensionSet/dimensionSetIO.C` (`dimensionSet::tokeniser`,
`dimensionSet::parse`, `dimensionSet::read`, `operator>>`) and
`src/OpenFOAM/dimensionedTypes/dimensionedType/dimensionedType.C`
(`dimensioned<Type>::initialise` / `::read`), plus the same grammar as it exists today in
OpenFOAM-12/14 (`src/OpenFOAM/symbols/symbolsTemplates.C`, `symbols::parseNoBegin`, used
for both `dimensionSet` and `unitConversion`/`unitSet`). The scale factors are
`etc/controlDict`, `DimensionSets/SICoeffs` — the table `_UNIT_SYMBOLS` already cites.

Three facts from those sources drive the change:

- `parse()` handles `*` and `/` (priority 2), `^` (priority 3), parentheses, and implicit
  multiplication of adjacent symbols. This is the same `read(is, multiplier)` used for a
  bare `dimensionSet`, so `[kg/m^3]` is legal there too.
- `cm`, `mm`, `km` are the only SICoeffs entries with a multiplier other than 1
  (`1e-2`, `1e-3`, `1e3`).
- `operator>>(Istream&, dimensionSet&)` is fatal when the multiplier is not 1 ("Cannot use
  scaled units in dimensionSet"); `dimensioned<Type>` instead applies it to the value
  (`value_ *= multiplier`, or `units.makeStandard(value_)` in 12/14). OpenFOAM-12/14 reach
  the same split differently: `cm` simply is not in the `dimensionSet` symbol table, only
  in the unit table.

### Change

- `_UNIT_MULTIPLIERS` alongside `_UNIT_SYMBOLS`, mirroring the SICoeffs scale column.
- `_SymbolTokenizer` splits a word on the characters `symbols::tokeniser::valid()` rejects,
  so `kg/m^3` becomes `kg` `/` `m` `^` `3`, and `_parse_unit_symbols` is now the
  recursive-descent evaluator, returning exponents *and* the multiplier.
- `_parse_dimensions` rejects a non-unit multiplier; `_parse_dimensioned` applies it to the
  parsed value (scalar or tensor).

### Deliberate behaviour changes

Two of #829's own assertions were wrong and are corrected here:

- `test_symbolic_dimensions` had `(b"[cm]", DimensionSet(length=1))`, which pinned the
  silent drop of the scale.
- `test_symbolic_dimensions_unknown_unit` asserted that `[kg/m^3]` must raise, with the
  comment *"'/' expressions belong to the dimensionedScalar grammar, not dimensionSet"*.
  That is not right: `dimensionSet::read(is, multiplier)` calls the same `parse()`, so `/`
  is legal in a bare `dimensionSet`; only a multiplier ≠ 1 is not.

Two more, where OpenFOAM-11 and 12/14 disagree and I followed 12/14:

- `[m 2]` — a bare number in the expression. OpenFOAM-11 folds it into the multiplier;
  12/14 reject it ("Illegal token"). Rejected here.
- `[m^]` — an empty power. OpenFOAM-11 treats the missing exponent as 1 (so foamlib
  currently returns `[m]`); 12/14 require a scalar after `^` ("Invalid power"). Rejected
  here.

I did not implement OpenFOAM-11's `dimensionSet::round(10*smallExponent)` after `^`; it was
dropped in 12/14's `pow(dimensionSet, scalar)`.

### Scope

Named dimensions (`_NAMED_DIMENSIONS`, OpenFOAM-14 `Foam::dimensions()`) are still only
accepted as a single bare token, so `[velocity time]` remains an error while `[m s^-1]`
works. That asymmetry is deliberate: no OpenFOAM version mixes the two symbol tables in one
expression, and a union grammar would be foamlib inventing behaviour. Happy to do it in a
follow-up if you would rather have it.

Honest note on frequency: none of the 4234 dictionaries shipped with OpenFOAM-11 use a
scaled unit or an operator inside `[...]` — every `[kg/m^3]`-style hit in the tutorials is
inside a comment. This is about hand-written dictionaries (and about `[Pa]`-style entries
like the one in #332), not about the shipped cases. What makes it worth fixing is that the
value case fails silently.

### Tests

`test_openfoam_grammar_tolerance.py` gains the operator/parenthesis cases, a scaled-unit
matrix over all three scaled symbols at both call sites, a tensor-valued case, and an
invalid-input set that pins `FoamFileDecodeError` as the only error type. 27 of them fail
on `main`. Full suite, `ruff check`, `ruff format --check` and `ty check` are unchanged
otherwise (the two `test_diffusioncheck` failures and the `FOAM_TUTORIALS` errors are
pre-existing in an environment without OpenFOAM).
