### PR TITLE
Revert trailing subdictionary support from #829

### DIFF
--- a/src/foamlib/_files/_normalization.py
+++ b/src/foamlib/_files/_normalization.py
@@ -345,12 +345,6 @@ def _normalized_data(
     match value:
         case DimensionSet():
             return value
-        case (v, {} as d):
-            # Data followed by a subdictionary (primitiveEntry value form)
-            return (
-                _normalized_data(v, keywords=keywords, binary=binary),  # ty: ignore[invalid-argument-type]
-                _normalized_dict(d),  # ty: ignore[invalid-argument-type]
-            )
         case tuple((_, _, *_)):
             return tuple(  # ty: ignore[invalid-return-type]
                 _normalized_data_entry(v, keywords=keywords, binary=binary)

--- a/src/foamlib/_files/_parsing/_parser.py
+++ b/src/foamlib/_files/_parsing/_parser.py
@@ -1052,10 +1052,11 @@ def _parse_keyword_entry(
     try:
         value, pos = _parse_dictionary(contents, pos)
     except ParseError:
-        value, pos = _parse_entry_value(contents, pos)
+        value, pos = _parse_data(contents, pos)
+        pos = _skip(contents, pos)
         pos = _expect(contents, pos, b";")
 
-    return (keyword, value), pos  # ty: ignore[invalid-return-type]
+    return (keyword, value), pos
 
 
 def _parse_dictionary(contents: bytes | bytearray, pos: int) -> tuple[Dict, int]:
@@ -1092,7 +1093,8 @@ def _parse_dictionary(contents: bytes | bytearray, pos: int) -> tuple[Dict, int]
         try:
             value, pos = _parse_dictionary(contents, pos)
         except ParseError:
-            value, pos = _parse_entry_value(contents, pos)
+            value, pos = _parse_data(contents, pos)
+            pos = _skip(contents, pos)
             pos = _expect(contents, pos, b";")
 
         ret[keyword] = value
@@ -1157,7 +1159,10 @@ def _parse_subdictionary(contents: bytes | bytearray, pos: int) -> tuple[SubDict
             try:
                 value, pos = _parse_subdictionary(contents, pos)
             except ParseError:
-                value, pos = _parse_entry_value(contents, pos)
+                try:
+                    value, pos = _parse_data(contents, pos)
+                except ParseError:
+                    value = None
                 if keyword.startswith("$") and value is None:
                     # Bare '$'-reference entry (whole-entry substitution)
                     if contents[pos : pos + 1] == b";":
@@ -1176,26 +1181,6 @@ def _parse_subdictionary(contents: bytes | bytearray, pos: int) -> tuple[SubDict
             ret = add_to_mapping(ret, keyword, value)
 
     return ret, pos
-
-
-def _parse_entry_value(
-    contents: bytes | bytearray, pos: int
-) -> tuple[Data | None, int]:
-    """Parse a keyword-entry value, allowing a trailing subdictionary.
-
-    OpenFOAM's ``primitiveEntry::read`` reads tokens until a ``;`` at block
-    depth zero, so ``key word(s) { ... };`` is a single entry whose value is
-    the data followed by the subdictionary.
-    """
-    try:
-        value, pos = _parse_data(contents, pos)
-    except ParseError:
-        return None, pos
-    pos = _skip(contents, pos)
-    if contents[pos : pos + 1] == b"{":
-        subdict, pos = _parse_subdictionary(contents, pos)
-        value = (value, subdict)
-    return value, pos
 
 
 def _parse_directive_value(
@@ -1326,7 +1311,10 @@ def _parse_file(contents: bytes | bytearray, pos: int = 0) -> tuple[FileDict, in
                 try:
                     value, new_pos = _parse_subdictionary(contents, new_pos)
                 except ParseError:
-                    value, new_pos = _parse_entry_value(contents, new_pos)
+                    try:
+                        value, new_pos = _parse_data(contents, new_pos)
+                    except ParseError:
+                        value = None
                     if keyword.startswith("$") and value is None:
                         # Bare '$'-reference entry (whole-entry substitution)
                         if contents[new_pos : new_pos + 1] == b";":
@@ -1461,7 +1449,10 @@ def _parse_file_located(
                 ret[(*_keywords, keyword)] = ParsedEntry(..., entry_start, new_pos)
                 ret.extend(subdict_result)
             else:
-                value, new_pos = _parse_entry_value(contents, new_pos)
+                try:
+                    value, new_pos = _parse_data(contents, new_pos)
+                except ParseError:
+                    value = None
                 if keyword.startswith("$") and value is None:
                     # Bare '$'-reference entry (whole-entry substitution)
                     if contents[new_pos : new_pos + 1] == b";":

--- a/tests/test_files/test_parsing/test_openfoam_grammar_tolerance.py
+++ b/tests/test_files/test_parsing/test_openfoam_grammar_tolerance.py
@@ -33,6 +33,7 @@ def test_spurious_semicolon_after_standalone_list() -> None:
     assert parsed[()] == [[0, 1, 2], [3, 4, 5], 1.0, 2.0, [1]]
 
 
+@pytest.mark.xfail
 def test_value_then_subdictionary() -> None:
     # primitiveEntry::read reads tokens until a ';' at blockCount 0, so a
     # trailing subdictionary is part of the value (fvSchemes ddtSchemes/
@@ -224,7 +225,7 @@ def test_grammar_tolerance_round_trip() -> None:
     cases = [
         b"a {x 1;}; b 2;",
         b"(\n (0 1 2) (3 4 5) 1.0 2.0 (1)\n);",
-        b"ddtSchemes {default CrankNicolson ocCoeff {type scale; value 0.9;};}",
+        # b"ddtSchemes {default CrankNicolson ocCoeff {type scale; value 0.9;};}",
         b"functions {#includeFunc fieldAverage(U, p)\n}",
         b"dimensions [m^2 s^-3];",
         b"TiO2_s {$TiO2}",


### PR DESCRIPTION
Previously accepted implementation breaks some current typing guarantees